### PR TITLE
Floating Inventory Item Info Box

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -166,6 +166,7 @@ set(libdevilutionx_SRCS
 
   qol/autopickup.cpp
   qol/chatlog.cpp
+  qol/floatinginfobox.cpp
   qol/floatingnumbers.cpp
   qol/itemlabels.cpp
   qol/monhealthbar.cpp

--- a/Source/control.h
+++ b/Source/control.h
@@ -180,6 +180,8 @@ void DrawSpellBook(const Surface &out);
 void DrawGoldSplit(const Surface &out);
 void control_drop_gold(SDL_Keycode vkey);
 void DrawTalkPan(const Surface &out);
+void DrawInvFloatingInfo(const Surface &out);
+void DrawStashFloatingInfo(const Surface &out);
 bool control_check_talk_btn();
 void control_release_talk_btn();
 void control_type_message();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1797,13 +1797,6 @@ void InitKeymapActions()
 	    nullptr,
 	    [] { ToggleItemLabelHighlight(); });
 	sgOptions.Keymapper.AddAction(
-	    "Show Extra Item Info",
-	    N_("Show Extra Item Info"),
-	    N_("Show extra item information in the floating info box."),
-	    SDLK_RSHIFT,
-	    [] { ExtraInfoKeyPressed(true); },
-	    [] { ExtraInfoKeyPressed(false); });
-	sgOptions.Keymapper.AddAction(
 	    "Toggle Automap",
 	    N_("Toggle automap"),
 	    N_("Toggles if automap is displayed."),
@@ -2354,13 +2347,6 @@ void InitPadmapActions()
 	    ControllerButton_NONE,
 	    nullptr,
 	    [] { ToggleItemLabelHighlight(); });
-	sgOptions.Padmapper.AddAction(
-	    "Show Extra Item Info",
-	    N_("Show Extra Item Info"),
-	    N_("Show extra item information in the floating info box."),
-	    ControllerButton_NONE,
-	    [] { ExtraInfoKeyPressed(true); },
-	    [] { ExtraInfoKeyPressed(false); });
 	sgOptions.Padmapper.AddAction(
 	    "Hide Info Screens",
 	    N_("Hide Info Screens"),

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -72,6 +72,7 @@
 #include "playerdat.hpp"
 #include "plrmsg.h"
 #include "qol/chatlog.h"
+#include "qol/floatinginfobox.hpp"
 #include "qol/floatingnumbers.h"
 #include "qol/itemlabels.h"
 #include "qol/monhealthbar.h"
@@ -1796,6 +1797,13 @@ void InitKeymapActions()
 	    nullptr,
 	    [] { ToggleItemLabelHighlight(); });
 	sgOptions.Keymapper.AddAction(
+	    "Show Extra Item Info",
+	    N_("Show Extra Item Info"),
+	    N_("Show extra item information in the floating info box."),
+	    SDLK_RSHIFT,
+	    [] { ExtraInfoKeyPressed(true); },
+	    [] { ExtraInfoKeyPressed(false); });
+	sgOptions.Keymapper.AddAction(
 	    "Toggle Automap",
 	    N_("Toggle automap"),
 	    N_("Toggles if automap is displayed."),
@@ -2346,6 +2354,13 @@ void InitPadmapActions()
 	    ControllerButton_NONE,
 	    nullptr,
 	    [] { ToggleItemLabelHighlight(); });
+	sgOptions.Padmapper.AddAction(
+	    "Show Extra Item Info",
+	    N_("Show Extra Item Info"),
+	    N_("Show extra item information in the floating info box."),
+	    ControllerButton_NONE,
+	    [] { ExtraInfoKeyPressed(true); },
+	    [] { ExtraInfoKeyPressed(false); });
 	sgOptions.Padmapper.AddAction(
 	    "Hide Info Screens",
 	    N_("Hide Info Screens"),

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1655,6 +1655,11 @@ void DrawAndBlit()
 	if (*sgOptions.Gameplay.showManaValues)
 		DrawFlaskValues(out, { mainPanel.position.x + mainPanel.size.width - 138, mainPanel.position.y + 28 }, MyPlayer->_pMana >> 6, MyPlayer->_pMaxMana >> 6);
 
+	if (*sgOptions.Gameplay.enableFloatingInfoBox) {
+		DrawInvFloatingInfo(out);
+		DrawStashFloatingInfo(out);
+	}
+
 	DrawCursor(out);
 
 	DrawFPS(out);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1940,10 +1940,15 @@ int8_t CheckInvHLight()
 	} else {
 		InfoColor = pi->getTextColor();
 		InfoString = pi->getName();
+
 		if (pi->_iIdentified) {
-			PrintItemDetails(*pi);
+			if (!*sgOptions.Gameplay.enableFloatingInfoBox) {
+				PrintItemDetails(*pi);
+			}
 		} else {
-			PrintItemDur(*pi);
+			if (!*sgOptions.Gameplay.enableFloatingInfoBox) {
+				PrintItemDur(*pi);
+			}
 		}
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -39,6 +39,7 @@
 #include "player.h"
 #include "playerdat.hpp"
 #include "qol/stash.h"
+#include "spelldat.h"
 #include "spells.h"
 #include "stores.h"
 #include "utils/format_int.hpp"

--- a/Source/monstdat.cpp
+++ b/Source/monstdat.cpp
@@ -205,114 +205,388 @@ const _monster_id MonstConvTbl[] = {
 	MT_LRDSAYTR,
 };
 
-/** Contains the data related to each unique monster ID. */
-const UniqueMonsterData UniqueMonstersData[] = {
-	// clang-format off
-// mtype,      mName,                                     mTrnName,   mlevel,  mmaxhp, mAi,                           mint,  mMinDamage,  mMaxDamage, mMagicRes,                                      monsterPack,                     customToHit,  customArmorClass, mtalkmsg
-	// TRANSLATORS: Unique Monster Block start
-{ MT_NGOATMC,  P_("monster", "Gharbad the Weak"),         "bsdb",          4,     120, MonsterAIID::Gharbad,             3,           8,          16, IMMUNE_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_GARBUD1  },
-{ MT_SKING,    P_("monster", "Skeleton King"),            "genrl",         0,     240, MonsterAIID::SkeletonKing,        3,           6,          16, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Independent,            0,                 0, TEXT_NONE     },
-{ MT_COUNSLR,  P_("monster", "Zhar the Mad"),             "general",       8,     360, MonsterAIID::Zhar,                3,          16,          40, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_ZHAR1    },
-{ MT_BFALLSP,  P_("monster", "Snotspill"),                "bng",           4,     220, MonsterAIID::Snotspill,           3,          10,          18, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_BANNER10 },
-{ MT_ADVOCATE, P_("monster", "Arch-Bishop Lazarus"),      "general",       0,     600, MonsterAIID::Lazarus,             3,          30,          50, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_VILE13   },
-{ MT_HLSPWN,   P_("monster", "Red Vex"),                  "redv",          0,     400, MonsterAIID::LazarusSuccubus,     3,          30,          50, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_VILE13   },
-{ MT_HLSPWN,   P_("monster", "Black Jade"),               "blkjd",         0,     400, MonsterAIID::LazarusSuccubus,     3,          30,          50, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_VILE13   },
-{ MT_RBLACK,   P_("monster", "Lachdanan"),                "bhka",         14,     500, MonsterAIID::Lachdanan,           3,           0,           0, 0,                                              UniqueMonsterPack::None,                   0,                 0, TEXT_VEIL9    },
-{ MT_BTBLACK,  P_("monster", "Warlord of Blood"),         "general",      13,     850, MonsterAIID::Warlord,             3,          35,          50, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_WARLRD9  },
-{ MT_CLEAVER,  P_("monster", "The Butcher"),              "genrl",         0,     220, MonsterAIID::Butcher,             3,           6,          12, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_HORKDMN,  P_("monster", "Hork Demon"),               "genrl",        19,     300, MonsterAIID::HorkDemon,           3,          20,          35, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_DEFILER,  P_("monster", "The Defiler"),              "genrl",        20,     480, MonsterAIID::SkeletonMelee,       3,          30,          40, RESIST_MAGIC | RESIST_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_NAKRUL,   P_("monster", "Na-Krul"),                  "genrl",         0,    1332, MonsterAIID::SkeletonMelee,       3,          40,          50, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_TSKELAX,  P_("monster", "Bonehead Keenaxe"),         "bhka",          2,      91, MonsterAIID::SkeletonMelee,       2,           4,          10, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,              100,                 0, TEXT_NONE     },
-{ MT_RFALLSD,  P_("monster", "Bladeskin the Slasher"),    "bsts",          2,      51, MonsterAIID::Fallen,              0,           6,          18, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
-{ MT_NZOMBIE,  P_("monster", "Soulpus"),                  "general",       2,     133, MonsterAIID::Zombie,              0,           4,           8, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_RFALLSP,  P_("monster", "Pukerat the Unclean"),      "ptu",           2,      77, MonsterAIID::Fallen,              3,           1,           5, RESIST_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_WSKELAX,  P_("monster", "Boneripper"),               "br",            2,      54, MonsterAIID::Bat,                 0,           6,          15, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_NZOMBIE,  P_("monster", "Rotfeast the Hungry"),      "eth",           2,      85, MonsterAIID::SkeletonMelee,       3,           4,          12, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_DFALLSD,  P_("monster", "Gutshank the Quick"),       "gtq",           3,      66, MonsterAIID::Bat,                 2,           6,          16, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_TSKELSD,  P_("monster", "Brokenhead Bangshield"),    "bhbs",          3,     108, MonsterAIID::SkeletonMelee,       3,          12,          20, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_YFALLSP,  P_("monster", "Bongo"),                    "bng",           3,     178, MonsterAIID::Fallen,              3,           9,          21, 0,                                              UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_BZOMBIE,  P_("monster", "Rotcarnage"),               "rcrn",          3,     102, MonsterAIID::Zombie,              3,           9,          24, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
-{ MT_NSCAV,    P_("monster", "Shadowbite"),               "shbt",          2,      60, MonsterAIID::SkeletonMelee,       3,           3,          20, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_WSKELBW,  P_("monster", "Deadeye"),                  "de",            2,      49, MonsterAIID::GoatRanged,          0,           6,           9, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_RSKELAX,  P_("monster", "Madeye the Dead"),          "mtd",           4,      75, MonsterAIID::Bat,                 0,           9,          21, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                30, TEXT_NONE     },
-{ MT_BSCAV,    P_("monster", "El Chupacabras"),           "general",       3,     120, MonsterAIID::GoatMelee,           0,          10,          18, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_TSKELBW,  P_("monster", "Skullfire"),                "skfr",          3,     125, MonsterAIID::GoatRanged,          1,           6,          10, IMMUNE_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_SNEAK,    P_("monster", "Warpskull"),                "tspo",          3,     117, MonsterAIID::Sneak,               2,           6,          18, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_GZOMBIE,  P_("monster", "Goretongue"),               "pmr",           3,     156, MonsterAIID::SkeletonMelee,       1,          15,          30, IMMUNE_MAGIC,                                   UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_WSCAV,    P_("monster", "Pulsecrawler"),             "bhka",          4,     150, MonsterAIID::Scavenger,           0,          16,          20, IMMUNE_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
-{ MT_BLINK,    P_("monster", "Moonbender"),               "general",       4,     135, MonsterAIID::Bat,                 0,           9,          27, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_BLINK,    P_("monster", "Wrathraven"),               "general",       5,     135, MonsterAIID::Bat,                 2,           9,          22, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_YSCAV,    P_("monster", "Spineeater"),               "general",       4,     180, MonsterAIID::Scavenger,           1,          18,          25, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_RSKELBW,  P_("monster", "Blackash the Burning"),     "bashtb",        4,     120, MonsterAIID::GoatRanged,          0,           6,          16, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_BFALLSD,  P_("monster", "Shadowcrow"),               "general",       5,     270, MonsterAIID::Sneak,               2,          12,          25, 0,                                              UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_LRDSAYTR, P_("monster", "Blightstone the Weak"),     "bhka",          4,     360, MonsterAIID::SkeletonMelee,       0,           4,          12, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,               70,                 0, TEXT_NONE     },
-{ MT_FAT,      P_("monster", "Bilefroth the Pit Master"), "bftp",          6,     210, MonsterAIID::Bat,                 1,          16,          23, IMMUNE_MAGIC | IMMUNE_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_NGOATBW,  P_("monster", "Bloodskin Darkbow"),        "bsdb",          5,     207, MonsterAIID::GoatRanged,          0,           3,          16, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                55, TEXT_NONE     },
-{ MT_GLOOM,    P_("monster", "Foulwing"),                 "db",            5,     246, MonsterAIID::Rhino,               3,          12,          28, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_XSKELSD,  P_("monster", "Shadowdrinker"),            "shdr",          5,     300, MonsterAIID::Sneak,               1,          18,          26, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                45, TEXT_NONE     },
-{ MT_UNSEEN,   P_("monster", "Hazeshifter"),              "bhka",          5,     285, MonsterAIID::Sneak,               3,          18,          30, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_NACID,    P_("monster", "Deathspit"),                "bfds",          6,     303, MonsterAIID::AcidUnique,          0,          12,          32, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_RGOATMC,  P_("monster", "Bloodgutter"),              "bgbl",          6,     315, MonsterAIID::Bat,                 1,          24,          34, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_BGOATMC,  P_("monster", "Deathshade Fleshmaul"),     "dsfm",          6,     276, MonsterAIID::Rhino,               0,          12,          24, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                65, TEXT_NONE     },
-{ MT_WYRM,     P_("monster", "Warmaggot the Mad"),        "general",       6,     246, MonsterAIID::Bat,                 3,          15,          30, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_STORM,    P_("monster", "Glasskull the Jagged"),     "bhka",          7,     354, MonsterAIID::Storm,               0,          18,          30, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_RGOATBW,  P_("monster", "Blightfire"),               "blf",           7,     321, MonsterAIID::Succubus,            2,          13,          21, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_GARGOYLE, P_("monster", "Nightwing the Cold"),       "general",       7,     342, MonsterAIID::Bat,                 1,          18,          26, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_GGOATBW,  P_("monster", "Gorestone"),                "general",       7,     303, MonsterAIID::GoatRanged,          1,          15,          28, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,               70,                 0, TEXT_NONE     },
-{ MT_BMAGMA,   P_("monster", "Bronzefist Firestone"),     "general",       8,     360, MonsterAIID::Magma,               0,          30,          36, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_INCIN,    P_("monster", "Wrathfire the Doomed"),     "wftd",          8,     270, MonsterAIID::SkeletonMelee,       2,          20,          30, IMMUNE_MAGIC | RESIST_FIRE |  RESIST_LIGHTNING, UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_NMAGMA,   P_("monster", "Firewound the Grim"),       "bhka",          8,     303, MonsterAIID::Magma,               0,          18,          22, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_MUDMAN,   P_("monster", "Baron Sludge"),             "bsm",           8,     315, MonsterAIID::Sneak,               3,          25,          34, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                75, TEXT_NONE     },
-{ MT_GGOATMC,  P_("monster", "Blighthorn Steelmace"),     "bhsm",          7,     250, MonsterAIID::Rhino,               0,          20,          28, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
-{ MT_RACID,    P_("monster", "Chaoshowler"),              "general",       8,     240, MonsterAIID::AcidUnique,          0,          12,          20, 0,                                              UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_REDDTH,   P_("monster", "Doomgrin the Rotting"),     "general",       8,     405, MonsterAIID::Storm,               3,          25,          50, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_FLAMLRD,  P_("monster", "Madburner"),                "general",       9,     270, MonsterAIID::Storm,               0,          20,          40, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_LTCHDMN,  P_("monster", "Bonesaw the Litch"),        "general",       9,     495, MonsterAIID::Storm,               2,          30,          55, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_MUDRUN,   P_("monster", "Breakspine"),               "general",       9,     351, MonsterAIID::Rhino,               0,          25,          34, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_REDDTH,   P_("monster", "Devilskull Sharpbone"),     "general",       9,     444, MonsterAIID::Storm,               1,          25,          40, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_STORM,    P_("monster", "Brokenstorm"),              "general",       9,     411, MonsterAIID::Storm,               2,          25,          36, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_RSTORM,   P_("monster", "Stormbane"),                "general",       9,     555, MonsterAIID::Storm,               3,          30,          30, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_TOAD,     P_("monster", "Oozedrool"),                "general",       9,     483, MonsterAIID::Fat,                 3,          25,          30, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_BLOODCLW, P_("monster", "Goldblight of the Flame"),  "general",      10,     405, MonsterAIID::Gargoyle,            0,          15,          35, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                80, TEXT_NONE     },
-{ MT_OBLORD,   P_("monster", "Blackstorm"),               "general",      10,     525, MonsterAIID::Rhino,               3,          20,          40, IMMUNE_MAGIC |               IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                90, TEXT_NONE     },
-{ MT_RACID,    P_("monster", "Plaguewrath"),              "general",      10,     450, MonsterAIID::AcidUnique,          2,          20,          30, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_RSTORM,   P_("monster", "The Flayer"),               "general",      10,     501, MonsterAIID::Storm,               1,          20,          35, RESIST_MAGIC | RESIST_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_FROSTC,   P_("monster", "Bluehorn"),                 "general",      11,     477, MonsterAIID::Rhino,               1,          25,          30, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                90, TEXT_NONE     },
-{ MT_HELLBURN, P_("monster", "Warpfire Hellspawn"),       "general",      11,     525, MonsterAIID::FireMan,             3,          10,          40, RESIST_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_NSNAKE,   P_("monster", "Fangspeir"),                "general",      11,     444, MonsterAIID::SkeletonMelee,       1,          15,          32, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_UDEDBLRG, P_("monster", "Festerskull"),              "general",      11,     600, MonsterAIID::Storm,               2,          15,          30, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_NBLACK,   P_("monster", "Lionskull the Bent"),       "general",      12,     525, MonsterAIID::SkeletonMelee,       2,          25,          25, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_COUNSLR,  P_("monster", "Blacktongue"),              "general",      12,     360, MonsterAIID::Counselor,           3,          15,          30, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_DEATHW,   P_("monster", "Viletouch"),                "general",      12,     525, MonsterAIID::Gargoyle,            3,          20,          40, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_RSNAKE,   P_("monster", "Viperflame"),               "general",      12,     570, MonsterAIID::SkeletonMelee,       1,          25,          35, IMMUNE_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_BSNAKE,   P_("monster", "Fangskin"),                 "bhka",         14,     681, MonsterAIID::SkeletonMelee,       2,          15,          50, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_SUCCUBUS, P_("monster", "Witchfire the Unholy"),     "general",      12,     444, MonsterAIID::Succubus,            3,          10,          20, IMMUNE_MAGIC | IMMUNE_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_BALROG,   P_("monster", "Blackskull"),               "bhka",         13,     750, MonsterAIID::SkeletonMelee,       3,          25,          40, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_UNRAV,    P_("monster", "Soulslash"),                "general",      12,     450, MonsterAIID::SkeletonMelee,       0,          25,          25, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_VTEXLRD,  P_("monster", "Windspawn"),                "general",      12,     711, MonsterAIID::SkeletonMelee,       1,          35,          40, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_GSNAKE,   P_("monster", "Lord of the Pit"),          "general",      13,     762, MonsterAIID::SkeletonMelee,       2,          25,          42, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_RTBLACK,  P_("monster", "Rustweaver"),               "general",      13,     400, MonsterAIID::SkeletonMelee,       3,           1,          60, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_HOLOWONE, P_("monster", "Howlingire the Shade"),     "general",      13,     450, MonsterAIID::SkeletonMelee,       2,          40,          75, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_MAEL,     P_("monster", "Doomcloud"),                "general",      13,     612, MonsterAIID::Storm,               1,           1,          60, RESIST_FIRE | IMMUNE_LIGHTNING,                 UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_PAINMSTR, P_("monster", "Bloodmoon Soulfire"),       "general",      13,     684, MonsterAIID::SkeletonMelee,       1,          15,          40, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_SNOWWICH, P_("monster", "Witchmoon"),                "general",      13,     310, MonsterAIID::Succubus,            3,          30,          40, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_VTEXLRD,  P_("monster", "Gorefeast"),                "general",      13,     771, MonsterAIID::SkeletonMelee,       3,          20,          55, RESIST_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_RTBLACK,  P_("monster", "Graywar the Slayer"),       "general",      14,     672, MonsterAIID::SkeletonMelee,       1,          30,          50, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_MAGISTR,  P_("monster", "Dreadjudge"),               "general",      14,     540, MonsterAIID::Counselor,           1,          30,          40, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_HLSPWN,   P_("monster", "Stareye the Witch"),        "general",      14,     726, MonsterAIID::Succubus,            2,          30,          50, IMMUNE_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_BTBLACK,  P_("monster", "Steelskull the Hunter"),    "general",      14,     831, MonsterAIID::SkeletonMelee,       3,          40,          50, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_RBLACK,   P_("monster", "Sir Gorash"),               "general",      16,    1050, MonsterAIID::SkeletonMelee,       1,          20,          60, 0,                                              UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_CABALIST, P_("monster", "The Vizier"),               "general",      15,     850, MonsterAIID::Counselor,           2,          25,          40, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_REALWEAV, P_("monster", "Zamphir"),                  "general",      15,     891, MonsterAIID::SkeletonMelee,       2,          30,          50, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_HLSPWN,   P_("monster", "Bloodlust"),                "general",      15,     825, MonsterAIID::Succubus,            1,          20,          55, IMMUNE_MAGIC |               IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_HLSPWN,   P_("monster", "Webwidow"),                 "general",      16,     774, MonsterAIID::Succubus,            1,          20,          50, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_SOLBRNR,  P_("monster", "Fleshdancer"),              "general",      16,     999, MonsterAIID::Succubus,            3,          30,          50, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-{ MT_OBLORD,   P_("monster", "Grimspike"),                "general",      19,     534, MonsterAIID::Sneak,               1,          25,          40, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-// TRANSLATORS: Unique Monster Block end
-{ MT_STORML,   P_("monster", "Doomlock"),                 "general",      28,     534, MonsterAIID::Sneak,               1,          35,          55, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
-{ MT_INVALID,  nullptr,                                   nullptr,         0,       0, MonsterAIID::Invalid,             0,           0,           0, 0,                                              UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
-	// clang-format on
-};
+namespace {
+
+tl::expected<_monster_id, std::string> ParseMonsterId(std::string_view value)
+{
+	if (value == "MT_NZOMBIE") return MT_NZOMBIE;
+	if (value == "MT_BZOMBIE") return MT_BZOMBIE;
+	if (value == "MT_GZOMBIE") return MT_GZOMBIE;
+	if (value == "MT_YZOMBIE") return MT_YZOMBIE;
+	if (value == "MT_RFALLSP") return MT_RFALLSP;
+	if (value == "MT_DFALLSP") return MT_DFALLSP;
+	if (value == "MT_YFALLSP") return MT_YFALLSP;
+	if (value == "MT_BFALLSP") return MT_BFALLSP;
+	if (value == "MT_WSKELAX") return MT_WSKELAX;
+	if (value == "MT_TSKELAX") return MT_TSKELAX;
+	if (value == "MT_RSKELAX") return MT_RSKELAX;
+	if (value == "MT_XSKELAX") return MT_XSKELAX;
+	if (value == "MT_RFALLSD") return MT_RFALLSD;
+	if (value == "MT_DFALLSD") return MT_DFALLSD;
+	if (value == "MT_YFALLSD") return MT_YFALLSD;
+	if (value == "MT_BFALLSD") return MT_BFALLSD;
+	if (value == "MT_NSCAV") return MT_NSCAV;
+	if (value == "MT_BSCAV") return MT_BSCAV;
+	if (value == "MT_WSCAV") return MT_WSCAV;
+	if (value == "MT_YSCAV") return MT_YSCAV;
+	if (value == "MT_WSKELBW") return MT_WSKELBW;
+	if (value == "MT_TSKELBW") return MT_TSKELBW;
+	if (value == "MT_RSKELBW") return MT_RSKELBW;
+	if (value == "MT_XSKELBW") return MT_XSKELBW;
+	if (value == "MT_WSKELSD") return MT_WSKELSD;
+	if (value == "MT_TSKELSD") return MT_TSKELSD;
+	if (value == "MT_RSKELSD") return MT_RSKELSD;
+	if (value == "MT_XSKELSD") return MT_XSKELSD;
+	if (value == "MT_SNEAK") return MT_SNEAK;
+	if (value == "MT_STALKER") return MT_STALKER;
+	if (value == "MT_UNSEEN") return MT_UNSEEN;
+	if (value == "MT_ILLWEAV") return MT_ILLWEAV;
+	if (value == "MT_NGOATMC") return MT_NGOATMC;
+	if (value == "MT_BGOATMC") return MT_BGOATMC;
+	if (value == "MT_RGOATMC") return MT_RGOATMC;
+	if (value == "MT_GGOATMC") return MT_GGOATMC;
+	if (value == "MT_FIEND") return MT_FIEND;
+	if (value == "MT_GLOOM") return MT_GLOOM;
+	if (value == "MT_BLINK") return MT_BLINK;
+	if (value == "MT_FAMILIAR") return MT_FAMILIAR;
+	if (value == "MT_NGOATBW") return MT_NGOATBW;
+	if (value == "MT_BGOATBW") return MT_BGOATBW;
+	if (value == "MT_RGOATBW") return MT_RGOATBW;
+	if (value == "MT_GGOATBW") return MT_GGOATBW;
+	if (value == "MT_NACID") return MT_NACID;
+	if (value == "MT_RACID") return MT_RACID;
+	if (value == "MT_BACID") return MT_BACID;
+	if (value == "MT_XACID") return MT_XACID;
+	if (value == "MT_SKING") return MT_SKING;
+	if (value == "MT_FAT") return MT_FAT;
+	if (value == "MT_MUDMAN") return MT_MUDMAN;
+	if (value == "MT_TOAD") return MT_TOAD;
+	if (value == "MT_FLAYED") return MT_FLAYED;
+	if (value == "MT_WYRM") return MT_WYRM;
+	if (value == "MT_CAVSLUG") return MT_CAVSLUG;
+	if (value == "MT_DEVOUR") return MT_DEVOUR;
+	if (value == "MT_DVLWYRM") return MT_DVLWYRM;
+	if (value == "MT_NMAGMA") return MT_NMAGMA;
+	if (value == "MT_YMAGMA") return MT_YMAGMA;
+	if (value == "MT_BMAGMA") return MT_BMAGMA;
+	if (value == "MT_WMAGMA") return MT_WMAGMA;
+	if (value == "MT_HORNED") return MT_HORNED;
+	if (value == "MT_MUDRUN") return MT_MUDRUN;
+	if (value == "MT_FROSTC") return MT_FROSTC;
+	if (value == "MT_OBLORD") return MT_OBLORD;
+	if (value == "MT_BONEDMN") return MT_BONEDMN;
+	if (value == "MT_REDDTH") return MT_REDDTH;
+	if (value == "MT_LTCHDMN") return MT_LTCHDMN;
+	if (value == "MT_UDEDBLRG") return MT_UDEDBLRG;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INCIN") return MT_INCIN;
+	if (value == "MT_FLAMLRD") return MT_FLAMLRD;
+	if (value == "MT_DOOMFIRE") return MT_DOOMFIRE;
+	if (value == "MT_HELLBURN") return MT_HELLBURN;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_RSTORM") return MT_RSTORM;
+	if (value == "MT_STORM") return MT_STORM;
+	if (value == "MT_STORML") return MT_STORML;
+	if (value == "MT_MAEL") return MT_MAEL;
+	if (value == "MT_WINGED") return MT_WINGED;
+	if (value == "MT_GARGOYLE") return MT_GARGOYLE;
+	if (value == "MT_BLOODCLW") return MT_BLOODCLW;
+	if (value == "MT_DEATHW") return MT_DEATHW;
+	if (value == "MT_MEGA") return MT_MEGA;
+	if (value == "MT_GUARD") return MT_GUARD;
+	if (value == "MT_VTEXLRD") return MT_VTEXLRD;
+	if (value == "MT_BALROG") return MT_BALROG;
+	if (value == "MT_NSNAKE") return MT_NSNAKE;
+	if (value == "MT_RSNAKE") return MT_RSNAKE;
+	if (value == "MT_GSNAKE") return MT_GSNAKE;
+	if (value == "MT_BSNAKE") return MT_BSNAKE;
+	if (value == "MT_NBLACK") return MT_NBLACK;
+	if (value == "MT_RTBLACK") return MT_RTBLACK;
+	if (value == "MT_BTBLACK") return MT_BTBLACK;
+	if (value == "MT_RBLACK") return MT_RBLACK;
+	if (value == "MT_UNRAV") return MT_UNRAV;
+	if (value == "MT_HOLOWONE") return MT_HOLOWONE;
+	if (value == "MT_PAINMSTR") return MT_PAINMSTR;
+	if (value == "MT_REALWEAV") return MT_REALWEAV;
+	if (value == "MT_SUCCUBUS") return MT_SUCCUBUS;
+	if (value == "MT_SNOWWICH") return MT_SNOWWICH;
+	if (value == "MT_HLSPWN") return MT_HLSPWN;
+	if (value == "MT_SOLBRNR") return MT_SOLBRNR;
+	if (value == "MT_COUNSLR") return MT_COUNSLR;
+	if (value == "MT_MAGISTR") return MT_MAGISTR;
+	if (value == "MT_CABALIST") return MT_CABALIST;
+	if (value == "MT_ADVOCATE") return MT_ADVOCATE;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_DIABLO") return MT_DIABLO;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_GOLEM") return MT_GOLEM;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_INVALID") return MT_INVALID;
+	if (value == "MT_BIGFALL") return MT_BIGFALL;
+	if (value == "MT_DARKMAGE") return MT_DARKMAGE;
+	if (value == "MT_HELLBOAR") return MT_HELLBOAR;
+	if (value == "MT_STINGER") return MT_STINGER;
+	if (value == "MT_PSYCHORB") return MT_PSYCHORB;
+	if (value == "MT_ARACHNON") return MT_ARACHNON;
+	if (value == "MT_FELLTWIN") return MT_FELLTWIN;
+	if (value == "MT_HORKSPWN") return MT_HORKSPWN;
+	if (value == "MT_VENMTAIL") return MT_VENMTAIL;
+	if (value == "MT_NECRMORB") return MT_NECRMORB;
+	if (value == "MT_SPIDLORD") return MT_SPIDLORD;
+	if (value == "MT_LASHWORM") return MT_LASHWORM;
+	if (value == "MT_TORCHANT") return MT_TORCHANT;
+	if (value == "MT_HORKDMN") return MT_HORKDMN;
+	if (value == "MT_DEFILER") return MT_DEFILER;
+	if (value == "MT_GRAVEDIG") return MT_GRAVEDIG;
+	if (value == "MT_TOMBRAT") return MT_TOMBRAT;
+	if (value == "MT_FIREBAT") return MT_FIREBAT;
+	if (value == "MT_SKLWING") return MT_SKLWING;
+	if (value == "MT_LICH") return MT_LICH;
+	if (value == "MT_CRYPTDMN") return MT_CRYPTDMN;
+	if (value == "MT_HELLBAT") return MT_HELLBAT;
+	if (value == "MT_BONEDEMN") return MT_BONEDEMN;
+	if (value == "MT_LICH") return MT_LICH;
+	if (value == "MT_BICLOPS") return MT_BICLOPS;
+	if (value == "MT_FLESTHNG") return MT_FLESTHNG;
+	if (value == "MT_REAPER") return MT_REAPER;
+	if (value == "MT_NAKRUL") return MT_NAKRUL;
+	if (value == "MT_CLEAVER") return MT_CLEAVER;
+	if (value == "MT_INVILORD") return MT_INVILORD;
+	if (value == "MT_LRDSAYTR") return MT_LRDSAYTR;
+	return tl::make_unexpected("Unknown enum value");
+}
+
+tl::expected<MonsterAvailability, std::string> ParseMonsterAvailability(std::string_view value)
+{
+	if (value == "Always") return MonsterAvailability::Always;
+	if (value == "Never") return MonsterAvailability::Never;
+	if (value == "Retail") return MonsterAvailability::Retail;
+	return tl::make_unexpected("Expected one of: Always, Never, or Retail");
+}
+
+tl::expected<MonsterAIID, std::string> ParseAiId(std::string_view value)
+{
+	if (value == "Zombie") return MonsterAIID::Zombie;
+	if (value == "Fat") return MonsterAIID::Fat;
+	if (value == "SkeletonMelee") return MonsterAIID::SkeletonMelee;
+	if (value == "SkeletonRanged") return MonsterAIID::SkeletonRanged;
+	if (value == "Scavenger") return MonsterAIID::Scavenger;
+	if (value == "Rhino") return MonsterAIID::Rhino;
+	if (value == "GoatMelee") return MonsterAIID::GoatMelee;
+	if (value == "GoatRanged") return MonsterAIID::GoatRanged;
+	if (value == "Fallen") return MonsterAIID::Fallen;
+	if (value == "Magma") return MonsterAIID::Magma;
+	if (value == "SkeletonKing") return MonsterAIID::SkeletonKing;
+	if (value == "Bat") return MonsterAIID::Bat;
+	if (value == "Gargoyle") return MonsterAIID::Gargoyle;
+	if (value == "Butcher") return MonsterAIID::Butcher;
+	if (value == "Succubus") return MonsterAIID::Succubus;
+	if (value == "Sneak") return MonsterAIID::Sneak;
+	if (value == "Storm") return MonsterAIID::Storm;
+	if (value == "FireMan") return MonsterAIID::FireMan;
+	if (value == "Gharbad") return MonsterAIID::Gharbad;
+	if (value == "Acid") return MonsterAIID::Acid;
+	if (value == "AcidUnique") return MonsterAIID::AcidUnique;
+	if (value == "Golem") return MonsterAIID::Golem;
+	if (value == "Zhar") return MonsterAIID::Zhar;
+	if (value == "Snotspill") return MonsterAIID::Snotspill;
+	if (value == "Snake") return MonsterAIID::Snake;
+	if (value == "Counselor") return MonsterAIID::Counselor;
+	if (value == "Mega") return MonsterAIID::Mega;
+	if (value == "Diablo") return MonsterAIID::Diablo;
+	if (value == "Lazarus") return MonsterAIID::Lazarus;
+	if (value == "LazarusSuccubus") return MonsterAIID::LazarusSuccubus;
+	if (value == "Lachdanan") return MonsterAIID::Lachdanan;
+	if (value == "Warlord") return MonsterAIID::Warlord;
+	if (value == "FireBat") return MonsterAIID::FireBat;
+	if (value == "Torchant") return MonsterAIID::Torchant;
+	if (value == "HorkDemon") return MonsterAIID::HorkDemon;
+	if (value == "Lich") return MonsterAIID::Lich;
+	if (value == "ArchLich") return MonsterAIID::ArchLich;
+	if (value == "Psychorb") return MonsterAIID::Psychorb;
+	if (value == "Necromorb") return MonsterAIID::Necromorb;
+	if (value == "BoneDemon") return MonsterAIID::BoneDemon;
+	return tl::make_unexpected("Unknown enum value");
+}
+
+tl::expected<monster_flag, std::string> ParseMonsterFlag(std::string_view value)
+{
+	if (value == "HIDDEN") return MFLAG_HIDDEN;
+	if (value == "LOCK_ANIMATION") return MFLAG_LOCK_ANIMATION;
+	if (value == "ALLOW_SPECIAL") return MFLAG_ALLOW_SPECIAL;
+	if (value == "TARGETS_MONSTER") return MFLAG_TARGETS_MONSTER;
+	if (value == "GOLEM") return MFLAG_GOLEM;
+	if (value == "QUEST_COMPLETE") return MFLAG_QUEST_COMPLETE;
+	if (value == "KNOCKBACK") return MFLAG_KNOCKBACK;
+	if (value == "SEARCH") return MFLAG_SEARCH;
+	if (value == "CAN_OPEN_DOOR") return MFLAG_CAN_OPEN_DOOR;
+	if (value == "NO_ENEMY") return MFLAG_NO_ENEMY;
+	if (value == "BERSERK") return MFLAG_BERSERK;
+	if (value == "NOLIFESTEAL") return MFLAG_NOLIFESTEAL;
+	return tl::make_unexpected("Unknown enum value");
+}
+
+tl::expected<MonsterClass, std::string> ParseMonsterClass(std::string_view value)
+{
+	if (value == "Undead") return MonsterClass::Undead;
+	if (value == "Demon") return MonsterClass::Demon;
+	if (value == "Animal") return MonsterClass::Animal;
+	return tl::make_unexpected("Unknown enum value");
+}
+
+tl::expected<monster_resistance, std::string> ParseMonsterResistance(std::string_view value)
+{
+	if (value == "RESIST_MAGIC") return RESIST_MAGIC;
+	if (value == "RESIST_FIRE") return RESIST_FIRE;
+	if (value == "RESIST_LIGHTNING") return RESIST_LIGHTNING;
+	if (value == "IMMUNE_MAGIC") return IMMUNE_MAGIC;
+	if (value == "IMMUNE_FIRE") return IMMUNE_FIRE;
+	if (value == "IMMUNE_LIGHTNING") return IMMUNE_LIGHTNING;
+	if (value == "IMMUNE_ACID") return IMMUNE_ACID;
+	return tl::make_unexpected("Unknown enum value");
+}
+
+tl::expected<UniqueMonsterPack, std::string> ParseUniqueMonsterPack(std::string_view value)
+{
+	if (value == "None") return UniqueMonsterPack::None;
+	if (value == "Independent") return UniqueMonsterPack::Independent;
+	if (value == "Leashed") return UniqueMonsterPack::Leashed;
+	return tl::make_unexpected("Unknown enum value");
+}
+
+void LoadMonstDat()
+{
+	const std::string_view filename = "txtdata\\monsters\\monstdat.tsv";
+	DataFile dataFile = DataFile::loadOrDie(filename);
+	dataFile.skipHeaderOrDie(filename);
+
+	MonstersData.clear();
+	MonstersData.reserve(dataFile.numRecords());
+	std::unordered_map<std::string, size_t> spritePathToId;
+	for (DataFileRecord record : dataFile) {
+		RecordReader reader { record, filename };
+		MonsterData &monster = MonstersData.emplace_back();
+		reader.advance(); // Skip the first column (monster ID).
+		reader.readString("name", monster.name);
+		{
+			std::string assetsSuffix;
+			reader.readString("assetsSuffix", assetsSuffix);
+			const auto [it, inserted] = spritePathToId.emplace(assetsSuffix, spritePathToId.size());
+			if (inserted)
+				MonsterSpritePaths.push_back(it->first);
+			monster.spriteId = static_cast<uint16_t>(it->second);
+		}
+		reader.readString("soundSuffix", monster.soundSuffix);
+		reader.readString("trnFile", monster.trnFile);
+		reader.read("availability", monster.availability, ParseMonsterAvailability);
+		reader.readInt("width", monster.width);
+		reader.readInt("image", monster.image);
+		reader.readBool("hasSpecial", monster.hasSpecial);
+		reader.readBool("hasSpecialSound", monster.hasSpecialSound);
+		reader.readIntArray("frames", monster.frames);
+		reader.readIntArray("rate", monster.rate);
+		reader.readInt("minDunLvl", monster.minDunLvl);
+		reader.readInt("maxDunLvl", monster.maxDunLvl);
+		reader.readInt("level", monster.level);
+		reader.readInt("hitPointsMinimum", monster.hitPointsMinimum);
+		reader.readInt("hitPointsMaximum", monster.hitPointsMaximum);
+		reader.read("ai", monster.ai, ParseAiId);
+		reader.readEnumList("abilityFlags", monster.abilityFlags, ParseMonsterFlag);
+		reader.readInt("intelligence", monster.intelligence);
+		reader.readInt("toHit", monster.toHit);
+		reader.readInt("animFrameNum", monster.animFrameNum);
+		reader.readInt("minDamage", monster.minDamage);
+		reader.readInt("maxDamage", monster.maxDamage);
+		reader.readInt("toHitSpecial", monster.toHitSpecial);
+		reader.readInt("animFrameNumSpecial", monster.animFrameNumSpecial);
+		reader.readInt("minDamageSpecial", monster.minDamageSpecial);
+		reader.readInt("maxDamageSpecial", monster.maxDamageSpecial);
+		reader.readInt("armorClass", monster.armorClass);
+		reader.read("monsterClass", monster.monsterClass, ParseMonsterClass);
+		reader.readEnumList("resistance", monster.resistance, ParseMonsterResistance);
+		reader.readEnumList("resistanceHell", monster.resistanceHell, ParseMonsterResistance);
+		reader.readInt("selectionType", monster.selectionType);
+
+		// treasure
+		// TODO: Replace this hack with proper parsing once items have been migrated to data files.
+		reader.read("treasure", monster.treasure, [](std::string_view value) -> tl::expected<uint16_t, std::string> {
+			if (value.empty()) return 0;
+			if (value == "None") return T_NODROP;
+			if (value == "Uniq(SKCROWN)") return Uniq(UITEM_SKCROWN);
+			if (value == "Uniq(CLEAVER)") return Uniq(UITEM_CLEAVER);
+			return tl::make_unexpected("Invalid value. NOTE: Parser is incomplete");
+		});
+
+		reader.readInt("exp", monster.exp);
+	}
+	MonstersData.shrink_to_fit();
+}
+
+void LoadUniqueMonstDat()
+{
+	const std::string_view filename = "txtdata\\monsters\\unique_monstdat.tsv";
+	DataFile dataFile = DataFile::loadOrDie(filename);
+	dataFile.skipHeaderOrDie(filename);
+
+	UniqueMonstersData.clear();
+	UniqueMonstersData.reserve(dataFile.numRecords());
+	for (DataFileRecord record : dataFile) {
+		RecordReader reader { record, filename };
+		UniqueMonsterData &monster = UniqueMonstersData.emplace_back();
+		reader.read("type", monster.mtype, ParseMonsterId);
+		reader.readString("name", monster.mName);
+		reader.readString("trn", monster.mTrnName);
+		reader.readInt("level", monster.mlevel);
+		reader.readInt("maxHp", monster.mmaxhp);
+		reader.read("ai", monster.mAi, ParseAiId);
+		reader.readInt("intelligence", monster.mint);
+		reader.readInt("minDamage", monster.mMinDamage);
+		reader.readInt("maxDamage", monster.mMaxDamage);
+		reader.readEnumList("resistance", monster.mMagicRes, ParseMonsterResistance);
+		reader.read("monsterPack", monster.monsterPack, ParseUniqueMonsterPack);
+		reader.readInt("customToHit", monster.customToHit);
+		reader.readInt("customArmorClass", monster.customArmorClass);
+
+		// talkMessage
+		// TODO: Replace this hack with proper parsing once messages have been migrated to data files.
+		reader.read("talkMessage", monster.mtalkmsg, [](std::string_view value) -> tl::expected<_speech_id, std::string> {
+			if (value.empty()) return TEXT_NONE;
+			if (value == "TEXT_GARBUD1") return TEXT_GARBUD1;
+			if (value == "TEXT_ZHAR1") return TEXT_ZHAR1;
+			if (value == "TEXT_BANNER10") return TEXT_BANNER10;
+			if (value == "TEXT_VILE13") return TEXT_VILE13;
+			if (value == "TEXT_VEIL9") return TEXT_VEIL9;
+			if (value == "TEXT_WARLRD9") return TEXT_WARLRD9;
+			return tl::make_unexpected("Invalid value. NOTE: Parser is incomplete");
+		});
+	}
+	UniqueMonstersData.shrink_to_fit();
+}
+
+} // namespace
+
+void LoadMonsterData()
+{
+	LoadMonstDat();
+	LoadUniqueMonstDat();
+}
+
+size_t GetNumMonsterSprites()
+{
+	return MonsterSpritePaths.size();
+}
 
 } // namespace devilution

--- a/Source/monstdat.cpp
+++ b/Source/monstdat.cpp
@@ -205,388 +205,114 @@ const _monster_id MonstConvTbl[] = {
 	MT_LRDSAYTR,
 };
 
-namespace {
-
-tl::expected<_monster_id, std::string> ParseMonsterId(std::string_view value)
-{
-	if (value == "MT_NZOMBIE") return MT_NZOMBIE;
-	if (value == "MT_BZOMBIE") return MT_BZOMBIE;
-	if (value == "MT_GZOMBIE") return MT_GZOMBIE;
-	if (value == "MT_YZOMBIE") return MT_YZOMBIE;
-	if (value == "MT_RFALLSP") return MT_RFALLSP;
-	if (value == "MT_DFALLSP") return MT_DFALLSP;
-	if (value == "MT_YFALLSP") return MT_YFALLSP;
-	if (value == "MT_BFALLSP") return MT_BFALLSP;
-	if (value == "MT_WSKELAX") return MT_WSKELAX;
-	if (value == "MT_TSKELAX") return MT_TSKELAX;
-	if (value == "MT_RSKELAX") return MT_RSKELAX;
-	if (value == "MT_XSKELAX") return MT_XSKELAX;
-	if (value == "MT_RFALLSD") return MT_RFALLSD;
-	if (value == "MT_DFALLSD") return MT_DFALLSD;
-	if (value == "MT_YFALLSD") return MT_YFALLSD;
-	if (value == "MT_BFALLSD") return MT_BFALLSD;
-	if (value == "MT_NSCAV") return MT_NSCAV;
-	if (value == "MT_BSCAV") return MT_BSCAV;
-	if (value == "MT_WSCAV") return MT_WSCAV;
-	if (value == "MT_YSCAV") return MT_YSCAV;
-	if (value == "MT_WSKELBW") return MT_WSKELBW;
-	if (value == "MT_TSKELBW") return MT_TSKELBW;
-	if (value == "MT_RSKELBW") return MT_RSKELBW;
-	if (value == "MT_XSKELBW") return MT_XSKELBW;
-	if (value == "MT_WSKELSD") return MT_WSKELSD;
-	if (value == "MT_TSKELSD") return MT_TSKELSD;
-	if (value == "MT_RSKELSD") return MT_RSKELSD;
-	if (value == "MT_XSKELSD") return MT_XSKELSD;
-	if (value == "MT_SNEAK") return MT_SNEAK;
-	if (value == "MT_STALKER") return MT_STALKER;
-	if (value == "MT_UNSEEN") return MT_UNSEEN;
-	if (value == "MT_ILLWEAV") return MT_ILLWEAV;
-	if (value == "MT_NGOATMC") return MT_NGOATMC;
-	if (value == "MT_BGOATMC") return MT_BGOATMC;
-	if (value == "MT_RGOATMC") return MT_RGOATMC;
-	if (value == "MT_GGOATMC") return MT_GGOATMC;
-	if (value == "MT_FIEND") return MT_FIEND;
-	if (value == "MT_GLOOM") return MT_GLOOM;
-	if (value == "MT_BLINK") return MT_BLINK;
-	if (value == "MT_FAMILIAR") return MT_FAMILIAR;
-	if (value == "MT_NGOATBW") return MT_NGOATBW;
-	if (value == "MT_BGOATBW") return MT_BGOATBW;
-	if (value == "MT_RGOATBW") return MT_RGOATBW;
-	if (value == "MT_GGOATBW") return MT_GGOATBW;
-	if (value == "MT_NACID") return MT_NACID;
-	if (value == "MT_RACID") return MT_RACID;
-	if (value == "MT_BACID") return MT_BACID;
-	if (value == "MT_XACID") return MT_XACID;
-	if (value == "MT_SKING") return MT_SKING;
-	if (value == "MT_FAT") return MT_FAT;
-	if (value == "MT_MUDMAN") return MT_MUDMAN;
-	if (value == "MT_TOAD") return MT_TOAD;
-	if (value == "MT_FLAYED") return MT_FLAYED;
-	if (value == "MT_WYRM") return MT_WYRM;
-	if (value == "MT_CAVSLUG") return MT_CAVSLUG;
-	if (value == "MT_DEVOUR") return MT_DEVOUR;
-	if (value == "MT_DVLWYRM") return MT_DVLWYRM;
-	if (value == "MT_NMAGMA") return MT_NMAGMA;
-	if (value == "MT_YMAGMA") return MT_YMAGMA;
-	if (value == "MT_BMAGMA") return MT_BMAGMA;
-	if (value == "MT_WMAGMA") return MT_WMAGMA;
-	if (value == "MT_HORNED") return MT_HORNED;
-	if (value == "MT_MUDRUN") return MT_MUDRUN;
-	if (value == "MT_FROSTC") return MT_FROSTC;
-	if (value == "MT_OBLORD") return MT_OBLORD;
-	if (value == "MT_BONEDMN") return MT_BONEDMN;
-	if (value == "MT_REDDTH") return MT_REDDTH;
-	if (value == "MT_LTCHDMN") return MT_LTCHDMN;
-	if (value == "MT_UDEDBLRG") return MT_UDEDBLRG;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INCIN") return MT_INCIN;
-	if (value == "MT_FLAMLRD") return MT_FLAMLRD;
-	if (value == "MT_DOOMFIRE") return MT_DOOMFIRE;
-	if (value == "MT_HELLBURN") return MT_HELLBURN;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_RSTORM") return MT_RSTORM;
-	if (value == "MT_STORM") return MT_STORM;
-	if (value == "MT_STORML") return MT_STORML;
-	if (value == "MT_MAEL") return MT_MAEL;
-	if (value == "MT_WINGED") return MT_WINGED;
-	if (value == "MT_GARGOYLE") return MT_GARGOYLE;
-	if (value == "MT_BLOODCLW") return MT_BLOODCLW;
-	if (value == "MT_DEATHW") return MT_DEATHW;
-	if (value == "MT_MEGA") return MT_MEGA;
-	if (value == "MT_GUARD") return MT_GUARD;
-	if (value == "MT_VTEXLRD") return MT_VTEXLRD;
-	if (value == "MT_BALROG") return MT_BALROG;
-	if (value == "MT_NSNAKE") return MT_NSNAKE;
-	if (value == "MT_RSNAKE") return MT_RSNAKE;
-	if (value == "MT_GSNAKE") return MT_GSNAKE;
-	if (value == "MT_BSNAKE") return MT_BSNAKE;
-	if (value == "MT_NBLACK") return MT_NBLACK;
-	if (value == "MT_RTBLACK") return MT_RTBLACK;
-	if (value == "MT_BTBLACK") return MT_BTBLACK;
-	if (value == "MT_RBLACK") return MT_RBLACK;
-	if (value == "MT_UNRAV") return MT_UNRAV;
-	if (value == "MT_HOLOWONE") return MT_HOLOWONE;
-	if (value == "MT_PAINMSTR") return MT_PAINMSTR;
-	if (value == "MT_REALWEAV") return MT_REALWEAV;
-	if (value == "MT_SUCCUBUS") return MT_SUCCUBUS;
-	if (value == "MT_SNOWWICH") return MT_SNOWWICH;
-	if (value == "MT_HLSPWN") return MT_HLSPWN;
-	if (value == "MT_SOLBRNR") return MT_SOLBRNR;
-	if (value == "MT_COUNSLR") return MT_COUNSLR;
-	if (value == "MT_MAGISTR") return MT_MAGISTR;
-	if (value == "MT_CABALIST") return MT_CABALIST;
-	if (value == "MT_ADVOCATE") return MT_ADVOCATE;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_DIABLO") return MT_DIABLO;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_GOLEM") return MT_GOLEM;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_INVALID") return MT_INVALID;
-	if (value == "MT_BIGFALL") return MT_BIGFALL;
-	if (value == "MT_DARKMAGE") return MT_DARKMAGE;
-	if (value == "MT_HELLBOAR") return MT_HELLBOAR;
-	if (value == "MT_STINGER") return MT_STINGER;
-	if (value == "MT_PSYCHORB") return MT_PSYCHORB;
-	if (value == "MT_ARACHNON") return MT_ARACHNON;
-	if (value == "MT_FELLTWIN") return MT_FELLTWIN;
-	if (value == "MT_HORKSPWN") return MT_HORKSPWN;
-	if (value == "MT_VENMTAIL") return MT_VENMTAIL;
-	if (value == "MT_NECRMORB") return MT_NECRMORB;
-	if (value == "MT_SPIDLORD") return MT_SPIDLORD;
-	if (value == "MT_LASHWORM") return MT_LASHWORM;
-	if (value == "MT_TORCHANT") return MT_TORCHANT;
-	if (value == "MT_HORKDMN") return MT_HORKDMN;
-	if (value == "MT_DEFILER") return MT_DEFILER;
-	if (value == "MT_GRAVEDIG") return MT_GRAVEDIG;
-	if (value == "MT_TOMBRAT") return MT_TOMBRAT;
-	if (value == "MT_FIREBAT") return MT_FIREBAT;
-	if (value == "MT_SKLWING") return MT_SKLWING;
-	if (value == "MT_LICH") return MT_LICH;
-	if (value == "MT_CRYPTDMN") return MT_CRYPTDMN;
-	if (value == "MT_HELLBAT") return MT_HELLBAT;
-	if (value == "MT_BONEDEMN") return MT_BONEDEMN;
-	if (value == "MT_LICH") return MT_LICH;
-	if (value == "MT_BICLOPS") return MT_BICLOPS;
-	if (value == "MT_FLESTHNG") return MT_FLESTHNG;
-	if (value == "MT_REAPER") return MT_REAPER;
-	if (value == "MT_NAKRUL") return MT_NAKRUL;
-	if (value == "MT_CLEAVER") return MT_CLEAVER;
-	if (value == "MT_INVILORD") return MT_INVILORD;
-	if (value == "MT_LRDSAYTR") return MT_LRDSAYTR;
-	return tl::make_unexpected("Unknown enum value");
-}
-
-tl::expected<MonsterAvailability, std::string> ParseMonsterAvailability(std::string_view value)
-{
-	if (value == "Always") return MonsterAvailability::Always;
-	if (value == "Never") return MonsterAvailability::Never;
-	if (value == "Retail") return MonsterAvailability::Retail;
-	return tl::make_unexpected("Expected one of: Always, Never, or Retail");
-}
-
-tl::expected<MonsterAIID, std::string> ParseAiId(std::string_view value)
-{
-	if (value == "Zombie") return MonsterAIID::Zombie;
-	if (value == "Fat") return MonsterAIID::Fat;
-	if (value == "SkeletonMelee") return MonsterAIID::SkeletonMelee;
-	if (value == "SkeletonRanged") return MonsterAIID::SkeletonRanged;
-	if (value == "Scavenger") return MonsterAIID::Scavenger;
-	if (value == "Rhino") return MonsterAIID::Rhino;
-	if (value == "GoatMelee") return MonsterAIID::GoatMelee;
-	if (value == "GoatRanged") return MonsterAIID::GoatRanged;
-	if (value == "Fallen") return MonsterAIID::Fallen;
-	if (value == "Magma") return MonsterAIID::Magma;
-	if (value == "SkeletonKing") return MonsterAIID::SkeletonKing;
-	if (value == "Bat") return MonsterAIID::Bat;
-	if (value == "Gargoyle") return MonsterAIID::Gargoyle;
-	if (value == "Butcher") return MonsterAIID::Butcher;
-	if (value == "Succubus") return MonsterAIID::Succubus;
-	if (value == "Sneak") return MonsterAIID::Sneak;
-	if (value == "Storm") return MonsterAIID::Storm;
-	if (value == "FireMan") return MonsterAIID::FireMan;
-	if (value == "Gharbad") return MonsterAIID::Gharbad;
-	if (value == "Acid") return MonsterAIID::Acid;
-	if (value == "AcidUnique") return MonsterAIID::AcidUnique;
-	if (value == "Golem") return MonsterAIID::Golem;
-	if (value == "Zhar") return MonsterAIID::Zhar;
-	if (value == "Snotspill") return MonsterAIID::Snotspill;
-	if (value == "Snake") return MonsterAIID::Snake;
-	if (value == "Counselor") return MonsterAIID::Counselor;
-	if (value == "Mega") return MonsterAIID::Mega;
-	if (value == "Diablo") return MonsterAIID::Diablo;
-	if (value == "Lazarus") return MonsterAIID::Lazarus;
-	if (value == "LazarusSuccubus") return MonsterAIID::LazarusSuccubus;
-	if (value == "Lachdanan") return MonsterAIID::Lachdanan;
-	if (value == "Warlord") return MonsterAIID::Warlord;
-	if (value == "FireBat") return MonsterAIID::FireBat;
-	if (value == "Torchant") return MonsterAIID::Torchant;
-	if (value == "HorkDemon") return MonsterAIID::HorkDemon;
-	if (value == "Lich") return MonsterAIID::Lich;
-	if (value == "ArchLich") return MonsterAIID::ArchLich;
-	if (value == "Psychorb") return MonsterAIID::Psychorb;
-	if (value == "Necromorb") return MonsterAIID::Necromorb;
-	if (value == "BoneDemon") return MonsterAIID::BoneDemon;
-	return tl::make_unexpected("Unknown enum value");
-}
-
-tl::expected<monster_flag, std::string> ParseMonsterFlag(std::string_view value)
-{
-	if (value == "HIDDEN") return MFLAG_HIDDEN;
-	if (value == "LOCK_ANIMATION") return MFLAG_LOCK_ANIMATION;
-	if (value == "ALLOW_SPECIAL") return MFLAG_ALLOW_SPECIAL;
-	if (value == "TARGETS_MONSTER") return MFLAG_TARGETS_MONSTER;
-	if (value == "GOLEM") return MFLAG_GOLEM;
-	if (value == "QUEST_COMPLETE") return MFLAG_QUEST_COMPLETE;
-	if (value == "KNOCKBACK") return MFLAG_KNOCKBACK;
-	if (value == "SEARCH") return MFLAG_SEARCH;
-	if (value == "CAN_OPEN_DOOR") return MFLAG_CAN_OPEN_DOOR;
-	if (value == "NO_ENEMY") return MFLAG_NO_ENEMY;
-	if (value == "BERSERK") return MFLAG_BERSERK;
-	if (value == "NOLIFESTEAL") return MFLAG_NOLIFESTEAL;
-	return tl::make_unexpected("Unknown enum value");
-}
-
-tl::expected<MonsterClass, std::string> ParseMonsterClass(std::string_view value)
-{
-	if (value == "Undead") return MonsterClass::Undead;
-	if (value == "Demon") return MonsterClass::Demon;
-	if (value == "Animal") return MonsterClass::Animal;
-	return tl::make_unexpected("Unknown enum value");
-}
-
-tl::expected<monster_resistance, std::string> ParseMonsterResistance(std::string_view value)
-{
-	if (value == "RESIST_MAGIC") return RESIST_MAGIC;
-	if (value == "RESIST_FIRE") return RESIST_FIRE;
-	if (value == "RESIST_LIGHTNING") return RESIST_LIGHTNING;
-	if (value == "IMMUNE_MAGIC") return IMMUNE_MAGIC;
-	if (value == "IMMUNE_FIRE") return IMMUNE_FIRE;
-	if (value == "IMMUNE_LIGHTNING") return IMMUNE_LIGHTNING;
-	if (value == "IMMUNE_ACID") return IMMUNE_ACID;
-	return tl::make_unexpected("Unknown enum value");
-}
-
-tl::expected<UniqueMonsterPack, std::string> ParseUniqueMonsterPack(std::string_view value)
-{
-	if (value == "None") return UniqueMonsterPack::None;
-	if (value == "Independent") return UniqueMonsterPack::Independent;
-	if (value == "Leashed") return UniqueMonsterPack::Leashed;
-	return tl::make_unexpected("Unknown enum value");
-}
-
-void LoadMonstDat()
-{
-	const std::string_view filename = "txtdata\\monsters\\monstdat.tsv";
-	DataFile dataFile = DataFile::loadOrDie(filename);
-	dataFile.skipHeaderOrDie(filename);
-
-	MonstersData.clear();
-	MonstersData.reserve(dataFile.numRecords());
-	std::unordered_map<std::string, size_t> spritePathToId;
-	for (DataFileRecord record : dataFile) {
-		RecordReader reader { record, filename };
-		MonsterData &monster = MonstersData.emplace_back();
-		reader.advance(); // Skip the first column (monster ID).
-		reader.readString("name", monster.name);
-		{
-			std::string assetsSuffix;
-			reader.readString("assetsSuffix", assetsSuffix);
-			const auto [it, inserted] = spritePathToId.emplace(assetsSuffix, spritePathToId.size());
-			if (inserted)
-				MonsterSpritePaths.push_back(it->first);
-			monster.spriteId = static_cast<uint16_t>(it->second);
-		}
-		reader.readString("soundSuffix", monster.soundSuffix);
-		reader.readString("trnFile", monster.trnFile);
-		reader.read("availability", monster.availability, ParseMonsterAvailability);
-		reader.readInt("width", monster.width);
-		reader.readInt("image", monster.image);
-		reader.readBool("hasSpecial", monster.hasSpecial);
-		reader.readBool("hasSpecialSound", monster.hasSpecialSound);
-		reader.readIntArray("frames", monster.frames);
-		reader.readIntArray("rate", monster.rate);
-		reader.readInt("minDunLvl", monster.minDunLvl);
-		reader.readInt("maxDunLvl", monster.maxDunLvl);
-		reader.readInt("level", monster.level);
-		reader.readInt("hitPointsMinimum", monster.hitPointsMinimum);
-		reader.readInt("hitPointsMaximum", monster.hitPointsMaximum);
-		reader.read("ai", monster.ai, ParseAiId);
-		reader.readEnumList("abilityFlags", monster.abilityFlags, ParseMonsterFlag);
-		reader.readInt("intelligence", monster.intelligence);
-		reader.readInt("toHit", monster.toHit);
-		reader.readInt("animFrameNum", monster.animFrameNum);
-		reader.readInt("minDamage", monster.minDamage);
-		reader.readInt("maxDamage", monster.maxDamage);
-		reader.readInt("toHitSpecial", monster.toHitSpecial);
-		reader.readInt("animFrameNumSpecial", monster.animFrameNumSpecial);
-		reader.readInt("minDamageSpecial", monster.minDamageSpecial);
-		reader.readInt("maxDamageSpecial", monster.maxDamageSpecial);
-		reader.readInt("armorClass", monster.armorClass);
-		reader.read("monsterClass", monster.monsterClass, ParseMonsterClass);
-		reader.readEnumList("resistance", monster.resistance, ParseMonsterResistance);
-		reader.readEnumList("resistanceHell", monster.resistanceHell, ParseMonsterResistance);
-		reader.readInt("selectionType", monster.selectionType);
-
-		// treasure
-		// TODO: Replace this hack with proper parsing once items have been migrated to data files.
-		reader.read("treasure", monster.treasure, [](std::string_view value) -> tl::expected<uint16_t, std::string> {
-			if (value.empty()) return 0;
-			if (value == "None") return T_NODROP;
-			if (value == "Uniq(SKCROWN)") return Uniq(UITEM_SKCROWN);
-			if (value == "Uniq(CLEAVER)") return Uniq(UITEM_CLEAVER);
-			return tl::make_unexpected("Invalid value. NOTE: Parser is incomplete");
-		});
-
-		reader.readInt("exp", monster.exp);
-	}
-	MonstersData.shrink_to_fit();
-}
-
-void LoadUniqueMonstDat()
-{
-	const std::string_view filename = "txtdata\\monsters\\unique_monstdat.tsv";
-	DataFile dataFile = DataFile::loadOrDie(filename);
-	dataFile.skipHeaderOrDie(filename);
-
-	UniqueMonstersData.clear();
-	UniqueMonstersData.reserve(dataFile.numRecords());
-	for (DataFileRecord record : dataFile) {
-		RecordReader reader { record, filename };
-		UniqueMonsterData &monster = UniqueMonstersData.emplace_back();
-		reader.read("type", monster.mtype, ParseMonsterId);
-		reader.readString("name", monster.mName);
-		reader.readString("trn", monster.mTrnName);
-		reader.readInt("level", monster.mlevel);
-		reader.readInt("maxHp", monster.mmaxhp);
-		reader.read("ai", monster.mAi, ParseAiId);
-		reader.readInt("intelligence", monster.mint);
-		reader.readInt("minDamage", monster.mMinDamage);
-		reader.readInt("maxDamage", monster.mMaxDamage);
-		reader.readEnumList("resistance", monster.mMagicRes, ParseMonsterResistance);
-		reader.read("monsterPack", monster.monsterPack, ParseUniqueMonsterPack);
-		reader.readInt("customToHit", monster.customToHit);
-		reader.readInt("customArmorClass", monster.customArmorClass);
-
-		// talkMessage
-		// TODO: Replace this hack with proper parsing once messages have been migrated to data files.
-		reader.read("talkMessage", monster.mtalkmsg, [](std::string_view value) -> tl::expected<_speech_id, std::string> {
-			if (value.empty()) return TEXT_NONE;
-			if (value == "TEXT_GARBUD1") return TEXT_GARBUD1;
-			if (value == "TEXT_ZHAR1") return TEXT_ZHAR1;
-			if (value == "TEXT_BANNER10") return TEXT_BANNER10;
-			if (value == "TEXT_VILE13") return TEXT_VILE13;
-			if (value == "TEXT_VEIL9") return TEXT_VEIL9;
-			if (value == "TEXT_WARLRD9") return TEXT_WARLRD9;
-			return tl::make_unexpected("Invalid value. NOTE: Parser is incomplete");
-		});
-	}
-	UniqueMonstersData.shrink_to_fit();
-}
-
-} // namespace
-
-void LoadMonsterData()
-{
-	LoadMonstDat();
-	LoadUniqueMonstDat();
-}
-
-size_t GetNumMonsterSprites()
-{
-	return MonsterSpritePaths.size();
-}
+/** Contains the data related to each unique monster ID. */
+const UniqueMonsterData UniqueMonstersData[] = {
+	// clang-format off
+// mtype,      mName,                                     mTrnName,   mlevel,  mmaxhp, mAi,                           mint,  mMinDamage,  mMaxDamage, mMagicRes,                                      monsterPack,                     customToHit,  customArmorClass, mtalkmsg
+	// TRANSLATORS: Unique Monster Block start
+{ MT_NGOATMC,  P_("monster", "Gharbad the Weak"),         "bsdb",          4,     120, MonsterAIID::Gharbad,             3,           8,          16, IMMUNE_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_GARBUD1  },
+{ MT_SKING,    P_("monster", "Skeleton King"),            "genrl",         0,     240, MonsterAIID::SkeletonKing,        3,           6,          16, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Independent,            0,                 0, TEXT_NONE     },
+{ MT_COUNSLR,  P_("monster", "Zhar the Mad"),             "general",       8,     360, MonsterAIID::Zhar,                3,          16,          40, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_ZHAR1    },
+{ MT_BFALLSP,  P_("monster", "Snotspill"),                "bng",           4,     220, MonsterAIID::Snotspill,           3,          10,          18, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_BANNER10 },
+{ MT_ADVOCATE, P_("monster", "Arch-Bishop Lazarus"),      "general",       0,     600, MonsterAIID::Lazarus,             3,          30,          50, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_VILE13   },
+{ MT_HLSPWN,   P_("monster", "Red Vex"),                  "redv",          0,     400, MonsterAIID::LazarusSuccubus,     3,          30,          50, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_VILE13   },
+{ MT_HLSPWN,   P_("monster", "Black Jade"),               "blkjd",         0,     400, MonsterAIID::LazarusSuccubus,     3,          30,          50, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_VILE13   },
+{ MT_RBLACK,   P_("monster", "Lachdanan"),                "bhka",         14,     500, MonsterAIID::Lachdanan,           3,           0,           0, 0,                                              UniqueMonsterPack::None,                   0,                 0, TEXT_VEIL9    },
+{ MT_BTBLACK,  P_("monster", "Warlord of Blood"),         "general",      13,     850, MonsterAIID::Warlord,             3,          35,          50, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_WARLRD9  },
+{ MT_CLEAVER,  P_("monster", "The Butcher"),              "genrl",         0,     220, MonsterAIID::Butcher,             3,           6,          12, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_HORKDMN,  P_("monster", "Hork Demon"),               "genrl",        19,     300, MonsterAIID::HorkDemon,           3,          20,          35, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_DEFILER,  P_("monster", "The Defiler"),              "genrl",        20,     480, MonsterAIID::SkeletonMelee,       3,          30,          40, RESIST_MAGIC | RESIST_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_NAKRUL,   P_("monster", "Na-Krul"),                  "genrl",         0,    1332, MonsterAIID::SkeletonMelee,       3,          40,          50, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_TSKELAX,  P_("monster", "Bonehead Keenaxe"),         "bhka",          2,      91, MonsterAIID::SkeletonMelee,       2,           4,          10, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,              100,                 0, TEXT_NONE     },
+{ MT_RFALLSD,  P_("monster", "Bladeskin the Slasher"),    "bsts",          2,      51, MonsterAIID::Fallen,              0,           6,          18, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
+{ MT_NZOMBIE,  P_("monster", "Soulpus"),                  "general",       2,     133, MonsterAIID::Zombie,              0,           4,           8, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_RFALLSP,  P_("monster", "Pukerat the Unclean"),      "ptu",           2,      77, MonsterAIID::Fallen,              3,           1,           5, RESIST_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_WSKELAX,  P_("monster", "Boneripper"),               "br",            2,      54, MonsterAIID::Bat,                 0,           6,          15, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_NZOMBIE,  P_("monster", "Rotfeast the Hungry"),      "eth",           2,      85, MonsterAIID::SkeletonMelee,       3,           4,          12, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_DFALLSD,  P_("monster", "Gutshank the Quick"),       "gtq",           3,      66, MonsterAIID::Bat,                 2,           6,          16, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_TSKELSD,  P_("monster", "Brokenhead Bangshield"),    "bhbs",          3,     108, MonsterAIID::SkeletonMelee,       3,          12,          20, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_YFALLSP,  P_("monster", "Bongo"),                    "bng",           3,     178, MonsterAIID::Fallen,              3,           9,          21, 0,                                              UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_BZOMBIE,  P_("monster", "Rotcarnage"),               "rcrn",          3,     102, MonsterAIID::Zombie,              3,           9,          24, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
+{ MT_NSCAV,    P_("monster", "Shadowbite"),               "shbt",          2,      60, MonsterAIID::SkeletonMelee,       3,           3,          20, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_WSKELBW,  P_("monster", "Deadeye"),                  "de",            2,      49, MonsterAIID::GoatRanged,          0,           6,           9, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_RSKELAX,  P_("monster", "Madeye the Dead"),          "mtd",           4,      75, MonsterAIID::Bat,                 0,           9,          21, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                30, TEXT_NONE     },
+{ MT_BSCAV,    P_("monster", "El Chupacabras"),           "general",       3,     120, MonsterAIID::GoatMelee,           0,          10,          18, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_TSKELBW,  P_("monster", "Skullfire"),                "skfr",          3,     125, MonsterAIID::GoatRanged,          1,           6,          10, IMMUNE_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_SNEAK,    P_("monster", "Warpskull"),                "tspo",          3,     117, MonsterAIID::Sneak,               2,           6,          18, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_GZOMBIE,  P_("monster", "Goretongue"),               "pmr",           3,     156, MonsterAIID::SkeletonMelee,       1,          15,          30, IMMUNE_MAGIC,                                   UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_WSCAV,    P_("monster", "Pulsecrawler"),             "bhka",          4,     150, MonsterAIID::Scavenger,           0,          16,          20, IMMUNE_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
+{ MT_BLINK,    P_("monster", "Moonbender"),               "general",       4,     135, MonsterAIID::Bat,                 0,           9,          27, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_BLINK,    P_("monster", "Wrathraven"),               "general",       5,     135, MonsterAIID::Bat,                 2,           9,          22, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_YSCAV,    P_("monster", "Spineeater"),               "general",       4,     180, MonsterAIID::Scavenger,           1,          18,          25, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_RSKELBW,  P_("monster", "Blackash the Burning"),     "bashtb",        4,     120, MonsterAIID::GoatRanged,          0,           6,          16, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_BFALLSD,  P_("monster", "Shadowcrow"),               "general",       5,     270, MonsterAIID::Sneak,               2,          12,          25, 0,                                              UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_LRDSAYTR, P_("monster", "Blightstone the Weak"),     "bhka",          4,     360, MonsterAIID::SkeletonMelee,       0,           4,          12, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,               70,                 0, TEXT_NONE     },
+{ MT_FAT,      P_("monster", "Bilefroth the Pit Master"), "bftp",          6,     210, MonsterAIID::Bat,                 1,          16,          23, IMMUNE_MAGIC | IMMUNE_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_NGOATBW,  P_("monster", "Bloodskin Darkbow"),        "bsdb",          5,     207, MonsterAIID::GoatRanged,          0,           3,          16, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                55, TEXT_NONE     },
+{ MT_GLOOM,    P_("monster", "Foulwing"),                 "db",            5,     246, MonsterAIID::Rhino,               3,          12,          28, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_XSKELSD,  P_("monster", "Shadowdrinker"),            "shdr",          5,     300, MonsterAIID::Sneak,               1,          18,          26, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::None,                   0,                45, TEXT_NONE     },
+{ MT_UNSEEN,   P_("monster", "Hazeshifter"),              "bhka",          5,     285, MonsterAIID::Sneak,               3,          18,          30, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_NACID,    P_("monster", "Deathspit"),                "bfds",          6,     303, MonsterAIID::AcidUnique,          0,          12,          32, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_RGOATMC,  P_("monster", "Bloodgutter"),              "bgbl",          6,     315, MonsterAIID::Bat,                 1,          24,          34, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_BGOATMC,  P_("monster", "Deathshade Fleshmaul"),     "dsfm",          6,     276, MonsterAIID::Rhino,               0,          12,          24, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                65, TEXT_NONE     },
+{ MT_WYRM,     P_("monster", "Warmaggot the Mad"),        "general",       6,     246, MonsterAIID::Bat,                 3,          15,          30, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_STORM,    P_("monster", "Glasskull the Jagged"),     "bhka",          7,     354, MonsterAIID::Storm,               0,          18,          30, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_RGOATBW,  P_("monster", "Blightfire"),               "blf",           7,     321, MonsterAIID::Succubus,            2,          13,          21, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_GARGOYLE, P_("monster", "Nightwing the Cold"),       "general",       7,     342, MonsterAIID::Bat,                 1,          18,          26, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_GGOATBW,  P_("monster", "Gorestone"),                "general",       7,     303, MonsterAIID::GoatRanged,          1,          15,          28, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,               70,                 0, TEXT_NONE     },
+{ MT_BMAGMA,   P_("monster", "Bronzefist Firestone"),     "general",       8,     360, MonsterAIID::Magma,               0,          30,          36, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_INCIN,    P_("monster", "Wrathfire the Doomed"),     "wftd",          8,     270, MonsterAIID::SkeletonMelee,       2,          20,          30, IMMUNE_MAGIC | RESIST_FIRE |  RESIST_LIGHTNING, UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_NMAGMA,   P_("monster", "Firewound the Grim"),       "bhka",          8,     303, MonsterAIID::Magma,               0,          18,          22, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_MUDMAN,   P_("monster", "Baron Sludge"),             "bsm",           8,     315, MonsterAIID::Sneak,               3,          25,          34, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                75, TEXT_NONE     },
+{ MT_GGOATMC,  P_("monster", "Blighthorn Steelmace"),     "bhsm",          7,     250, MonsterAIID::Rhino,               0,          20,          28, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                45, TEXT_NONE     },
+{ MT_RACID,    P_("monster", "Chaoshowler"),              "general",       8,     240, MonsterAIID::AcidUnique,          0,          12,          20, 0,                                              UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_REDDTH,   P_("monster", "Doomgrin the Rotting"),     "general",       8,     405, MonsterAIID::Storm,               3,          25,          50, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_FLAMLRD,  P_("monster", "Madburner"),                "general",       9,     270, MonsterAIID::Storm,               0,          20,          40, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_LTCHDMN,  P_("monster", "Bonesaw the Litch"),        "general",       9,     495, MonsterAIID::Storm,               2,          30,          55, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_MUDRUN,   P_("monster", "Breakspine"),               "general",       9,     351, MonsterAIID::Rhino,               0,          25,          34, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_REDDTH,   P_("monster", "Devilskull Sharpbone"),     "general",       9,     444, MonsterAIID::Storm,               1,          25,          40, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_STORM,    P_("monster", "Brokenstorm"),              "general",       9,     411, MonsterAIID::Storm,               2,          25,          36, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_RSTORM,   P_("monster", "Stormbane"),                "general",       9,     555, MonsterAIID::Storm,               3,          30,          30, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_TOAD,     P_("monster", "Oozedrool"),                "general",       9,     483, MonsterAIID::Fat,                 3,          25,          30, RESIST_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_BLOODCLW, P_("monster", "Goldblight of the Flame"),  "general",      10,     405, MonsterAIID::Gargoyle,            0,          15,          35, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                80, TEXT_NONE     },
+{ MT_OBLORD,   P_("monster", "Blackstorm"),               "general",      10,     525, MonsterAIID::Rhino,               3,          20,          40, IMMUNE_MAGIC |               IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                90, TEXT_NONE     },
+{ MT_RACID,    P_("monster", "Plaguewrath"),              "general",      10,     450, MonsterAIID::AcidUnique,          2,          20,          30, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_RSTORM,   P_("monster", "The Flayer"),               "general",      10,     501, MonsterAIID::Storm,               1,          20,          35, RESIST_MAGIC | RESIST_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_FROSTC,   P_("monster", "Bluehorn"),                 "general",      11,     477, MonsterAIID::Rhino,               1,          25,          30, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                90, TEXT_NONE     },
+{ MT_HELLBURN, P_("monster", "Warpfire Hellspawn"),       "general",      11,     525, MonsterAIID::FireMan,             3,          10,          40, RESIST_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_NSNAKE,   P_("monster", "Fangspeir"),                "general",      11,     444, MonsterAIID::SkeletonMelee,       1,          15,          32, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_UDEDBLRG, P_("monster", "Festerskull"),              "general",      11,     600, MonsterAIID::Storm,               2,          15,          30, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_NBLACK,   P_("monster", "Lionskull the Bent"),       "general",      12,     525, MonsterAIID::SkeletonMelee,       2,          25,          25, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_COUNSLR,  P_("monster", "Blacktongue"),              "general",      12,     360, MonsterAIID::Counselor,           3,          15,          30, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_DEATHW,   P_("monster", "Viletouch"),                "general",      12,     525, MonsterAIID::Gargoyle,            3,          20,          40, IMMUNE_LIGHTNING,                               UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_RSNAKE,   P_("monster", "Viperflame"),               "general",      12,     570, MonsterAIID::SkeletonMelee,       1,          25,          35, IMMUNE_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_BSNAKE,   P_("monster", "Fangskin"),                 "bhka",         14,     681, MonsterAIID::SkeletonMelee,       2,          15,          50, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_SUCCUBUS, P_("monster", "Witchfire the Unholy"),     "general",      12,     444, MonsterAIID::Succubus,            3,          10,          20, IMMUNE_MAGIC | IMMUNE_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_BALROG,   P_("monster", "Blackskull"),               "bhka",         13,     750, MonsterAIID::SkeletonMelee,       3,          25,          40, IMMUNE_MAGIC |               RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_UNRAV,    P_("monster", "Soulslash"),                "general",      12,     450, MonsterAIID::SkeletonMelee,       0,          25,          25, IMMUNE_MAGIC,                                   UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_VTEXLRD,  P_("monster", "Windspawn"),                "general",      12,     711, MonsterAIID::SkeletonMelee,       1,          35,          40, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_GSNAKE,   P_("monster", "Lord of the Pit"),          "general",      13,     762, MonsterAIID::SkeletonMelee,       2,          25,          42, RESIST_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_RTBLACK,  P_("monster", "Rustweaver"),               "general",      13,     400, MonsterAIID::SkeletonMelee,       3,           1,          60, IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_HOLOWONE, P_("monster", "Howlingire the Shade"),     "general",      13,     450, MonsterAIID::SkeletonMelee,       2,          40,          75, RESIST_FIRE | RESIST_LIGHTNING,                 UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_MAEL,     P_("monster", "Doomcloud"),                "general",      13,     612, MonsterAIID::Storm,               1,           1,          60, RESIST_FIRE | IMMUNE_LIGHTNING,                 UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_PAINMSTR, P_("monster", "Bloodmoon Soulfire"),       "general",      13,     684, MonsterAIID::SkeletonMelee,       1,          15,          40, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_SNOWWICH, P_("monster", "Witchmoon"),                "general",      13,     310, MonsterAIID::Succubus,            3,          30,          40, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_VTEXLRD,  P_("monster", "Gorefeast"),                "general",      13,     771, MonsterAIID::SkeletonMelee,       3,          20,          55, RESIST_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_RTBLACK,  P_("monster", "Graywar the Slayer"),       "general",      14,     672, MonsterAIID::SkeletonMelee,       1,          30,          50, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_MAGISTR,  P_("monster", "Dreadjudge"),               "general",      14,     540, MonsterAIID::Counselor,           1,          30,          40, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_HLSPWN,   P_("monster", "Stareye the Witch"),        "general",      14,     726, MonsterAIID::Succubus,            2,          30,          50, IMMUNE_FIRE,                                    UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_BTBLACK,  P_("monster", "Steelskull the Hunter"),    "general",      14,     831, MonsterAIID::SkeletonMelee,       3,          40,          50, RESIST_LIGHTNING,                               UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_RBLACK,   P_("monster", "Sir Gorash"),               "general",      16,    1050, MonsterAIID::SkeletonMelee,       1,          20,          60, 0,                                              UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_CABALIST, P_("monster", "The Vizier"),               "general",      15,     850, MonsterAIID::Counselor,           2,          25,          40, IMMUNE_FIRE,                                    UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_REALWEAV, P_("monster", "Zamphir"),                  "general",      15,     891, MonsterAIID::SkeletonMelee,       2,          30,          50, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_HLSPWN,   P_("monster", "Bloodlust"),                "general",      15,     825, MonsterAIID::Succubus,            1,          20,          55, IMMUNE_MAGIC |               IMMUNE_LIGHTNING,  UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_HLSPWN,   P_("monster", "Webwidow"),                 "general",      16,     774, MonsterAIID::Succubus,            1,          20,          50, IMMUNE_MAGIC | IMMUNE_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_SOLBRNR,  P_("monster", "Fleshdancer"),              "general",      16,     999, MonsterAIID::Succubus,            3,          30,          50, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+{ MT_OBLORD,   P_("monster", "Grimspike"),                "general",      19,     534, MonsterAIID::Sneak,               1,          25,          40, IMMUNE_MAGIC | RESIST_FIRE,                     UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+// TRANSLATORS: Unique Monster Block end
+{ MT_STORML,   P_("monster", "Doomlock"),                 "general",      28,     534, MonsterAIID::Sneak,               1,          35,          55, IMMUNE_MAGIC | RESIST_FIRE | RESIST_LIGHTNING,  UniqueMonsterPack::Leashed,                0,                 0, TEXT_NONE     },
+{ MT_INVALID,  nullptr,                                   nullptr,         0,       0, MonsterAIID::Invalid,             0,           0,           0, 0,                                              UniqueMonsterPack::None,                   0,                 0, TEXT_NONE     },
+	// clang-format on
+};
 
 } // namespace devilution

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1083,6 +1083,7 @@ GameplayOptions::GameplayOptions()
               { FloatingNumbers::Random, N_("Random Angles") },
               { FloatingNumbers::Vertical, N_("Vertical Only") },
           })
+    , enableFloatingInfoBox("Enable Floating Info Box", OptionEntryFlags::None, N_("Enable Floating Info Box"), N_("Moves information from the control panel to a floating box."), false)
 {
 	grabInput.SetValueChangedCallback(OptionGrabInputChanged);
 	experienceBar.SetValueChangedCallback(OptionExperienceBarChanged);
@@ -1128,6 +1129,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&disableCripplingShrines,
 		&adriaRefillsMana,
 		&grabInput,
+		&enableFloatingInfoBox,
 	};
 }
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -596,6 +596,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryInt<int> numFullRejuPotionPickup;
 	/** @brief Enable floating numbers. */
 	OptionEntryEnum<FloatingNumbers> enableFloatingNumbers;
+	/** @brief Enable floating info box. */
+	OptionEntryBoolean enableFloatingInfoBox;
 };
 
 struct ControllerOptions : OptionCategoryBase {

--- a/Source/qol/floatinginfobox.cpp
+++ b/Source/qol/floatinginfobox.cpp
@@ -1,0 +1,731 @@
+/**
+ * @file floatinginfobox.cpp
+ *
+ * Adds floating info box QoL feature
+ */
+
+#include "qol/floatinginfobox.hpp"
+
+#include "itemlabels.h"
+
+#include <algorithm>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "control.h"
+#include "controls/plrctrls.h"
+#include "cursor.h"
+#include "engine/point.hpp"
+#include "engine/render/clx_render.hpp"
+#include "gmenu.h"
+#include "inv.h"
+#include "options.h"
+#include "qol/stash.h"
+#include "utils/format_int.hpp"
+#include "utils/language.h"
+#include "utils/stdcompat/string_view.hpp"
+
+namespace devilution {
+
+namespace {
+
+bool extraInfoKeyPressed = false;
+
+} // namespace
+
+void ExtraInfoKeyPressed(bool pressed)
+{
+	extraInfoKeyPressed = pressed;
+}
+
+enum class ItemStatType {
+	Damage,
+	Armor,
+	Durability
+};
+
+UiFlags GetItemBonusColors(const ItemStatType stat, const Item &item)
+{
+	ItemData iData = AllItemsList[item.IDidx];
+	UiFlags color = UiFlags::ColorWhite;
+
+	if (item._iMagical == ITEM_QUALITY_UNIQUE) {
+		const UniqueItem &uitem = UniqueItems[item._iUid];
+		assert(uitem.UINumPL <= sizeof(uitem.powers) / sizeof(*uitem.powers));
+		for (const auto &power : uitem.powers) {
+			switch (power.type) {
+			case IPL_ACP:
+				if (stat == ItemStatType::Armor)
+					color = UiFlags::ColorBlue;
+				break;
+			case IPL_ACP_CURSE:
+				if (stat == ItemStatType::Armor)
+					color = UiFlags::ColorRed;
+				break;
+			case IPL_SETAC:
+			case IPL_AC_CURSE:
+				if (stat == ItemStatType::Armor) {
+					if (item._iAC > iData.iMaxAC)
+						color = UiFlags::ColorBlue;
+					else if (item._iAC < iData.iMinAC)
+						color = UiFlags::ColorRed;
+				}
+				break;
+			case IPL_DAMMOD:
+			case IPL_DAMP:
+			case IPL_TOHIT_DAMP:
+				if (stat == ItemStatType::Damage)
+					color = UiFlags::ColorBlue;
+				break;
+			case IPL_DAMP_CURSE:
+			case IPL_TOHIT_DAMP_CURSE:
+				if (stat == ItemStatType::Damage)
+					color = UiFlags::ColorRed;
+				break;
+			case IPL_SETDAM:
+				if (stat == ItemStatType::Damage) {
+					if ((item._iMinDam > iData.iMinDam) || (item._iMaxDam > iData.iMaxDam))
+						color = UiFlags::ColorBlue;
+					else if ((item._iMinDam < iData.iMinDam) || (item._iMaxDam < iData.iMaxDam))
+						color = UiFlags::ColorRed;
+				}
+				break;
+			case IPL_DUR:
+				if (stat == ItemStatType::Durability)
+					color = UiFlags::ColorBlue;
+				break;
+			case IPL_DUR_CURSE:
+				if (stat == ItemStatType::Durability)
+					color = UiFlags::ColorRed;
+				break;
+			case IPL_SETDUR:
+				if (stat == ItemStatType::Durability) {
+					if (item._iMaxDur > iData.iDurability)
+						color = UiFlags::ColorBlue;
+					else if (item._iMaxDur < iData.iDurability)
+						color = UiFlags::ColorRed;
+				}
+				break;
+			default:
+				break;
+			}
+		}
+	} else if (item._iMagical == ITEM_QUALITY_MAGIC) {
+		switch (item._iPrePower) {
+		case IPL_ACP:
+			if (stat == ItemStatType::Armor)
+				color = UiFlags::ColorBlue;
+			break;
+		case IPL_ACP_CURSE:
+			if (stat == ItemStatType::Armor)
+				color = UiFlags::ColorRed;
+			break;
+		case IPL_DAMP:
+		case IPL_TOHIT_DAMP:
+			if (stat == ItemStatType::Damage)
+				color = UiFlags::ColorBlue;
+			break;
+		case IPL_DAMP_CURSE:
+		case IPL_TOHIT_DAMP_CURSE:
+			if (stat == ItemStatType::Damage)
+				color = UiFlags::ColorRed;
+			break;
+		default:
+			break;
+		}
+		switch (item._iSufPower) {
+		case IPL_DUR:
+			if (stat == ItemStatType::Durability)
+				color = UiFlags::ColorBlue;
+			break;
+		case IPL_DUR_CURSE:
+			if (stat == ItemStatType::Durability)
+				color = UiFlags::ColorRed;
+			break;
+		default:
+			break;
+		}
+	}
+
+	return color;
+}
+
+enum class ItemRequirementType {
+	Strength,
+	Dexterity,
+	Magic
+};
+
+UiFlags GetItemRequirementColors(const ItemRequirementType stat, const Item &item)
+{
+	const Player &myPlayer = *MyPlayer;
+	const UiFlags colorMinRequirementMet = UiFlags::ColorWhite;
+	const UiFlags colorMinRequirementNotMet = UiFlags::ColorRed;
+
+	UiFlags color = colorMinRequirementMet;
+
+	if (stat == ItemRequirementType::Strength) {
+		if (item._iMinStr > myPlayer._pStrength)
+			color = colorMinRequirementNotMet;
+	} else if (stat == ItemRequirementType::Dexterity) {
+		if (item._iMinDex > myPlayer._pDexterity)
+			color = colorMinRequirementNotMet;
+	} else if (stat == ItemRequirementType::Magic) {
+		if (item._iMinMag > myPlayer._pMagic)
+			color = colorMinRequirementNotMet;
+	}
+
+	return color;
+}
+
+enum class ItemStatModifier {
+	MinDamage,
+	MaxDamage,
+	Armor
+};
+
+void CalculateArmorPercentMod(const Item &item, int16_t &modifiedArmor)
+{
+	modifiedArmor = modifiedArmor * (item._iPLAC + 100) / 100;
+}
+
+void CalculateDamPercentMod(const Item &item, int16_t &modifiedDam)
+{
+	modifiedDam = modifiedDam * (item._iPLDam + 100) / 100;
+}
+
+void CalculateDamMod(const Item &item, int16_t &modifiedDam)
+{
+	modifiedDam = modifiedDam + item._iPLDamMod;
+}
+
+int16_t CalculateModifiedStatValue(const ItemStatModifier stat, const Item &item)
+{
+	assert(IsAnyOf(stat, ItemStatModifier::MinDamage, ItemStatModifier::MaxDamage, ItemStatModifier::Armor));
+
+	int16_t modifiedMinDam = item._iMinDam;
+	int16_t modifiedMaxDam = item._iMaxDam;
+	int16_t modifiedArmor = item._iAC;
+
+	if (item._iMagical == ITEM_QUALITY_UNIQUE) {
+		const UniqueItem &uitem = UniqueItems[item._iUid];
+		assert(uitem.UINumPL <= sizeof(uitem.powers) / sizeof(*uitem.powers));
+
+		for (const auto &power : uitem.powers) {
+			switch (power.type) {
+			case IPL_ACP:
+			case IPL_ACP_CURSE:
+				if (stat == ItemStatModifier::Armor) {
+					CalculateArmorPercentMod(item, modifiedArmor);
+				}
+				break;
+			case IPL_DAMP:
+			case IPL_DAMP_CURSE:
+			case IPL_TOHIT_DAMP:
+			case IPL_TOHIT_DAMP_CURSE:
+				if (stat == ItemStatModifier::MinDamage) {
+					CalculateDamPercentMod(item, modifiedMinDam);
+				} else if (stat == ItemStatModifier::MaxDamage) {
+					CalculateDamPercentMod(item, modifiedMaxDam);
+				}
+				break;
+			case IPL_DAMMOD:
+				if (stat == ItemStatModifier::MinDamage) {
+					CalculateDamMod(item, modifiedMinDam);
+				} else if (stat == ItemStatModifier::MaxDamage) {
+					CalculateDamMod(item, modifiedMaxDam);
+				}
+				break;
+			default:
+				break;
+			}
+		}
+	} else if (item._iMagical == ITEM_QUALITY_MAGIC) {
+		switch (item._iPrePower) {
+		case IPL_ACP:
+		case IPL_ACP_CURSE:
+			if (stat == ItemStatModifier::Armor) {
+				CalculateArmorPercentMod(item, modifiedArmor);
+			}
+			break;
+		case IPL_DAMP:
+		case IPL_DAMP_CURSE:
+		case IPL_TOHIT_DAMP:
+		case IPL_TOHIT_DAMP_CURSE:
+			if (stat == ItemStatModifier::MinDamage) {
+				CalculateDamPercentMod(item, modifiedMinDam);
+			} else if (stat == ItemStatModifier::MaxDamage) {
+				CalculateDamPercentMod(item, modifiedMaxDam);
+			}
+			break;
+		default:
+			break;
+		}
+
+		switch (item._iSufPower) {
+		case IPL_DAMMOD:
+			if (stat == ItemStatModifier::MinDamage)
+				CalculateDamPercentMod(item, modifiedMinDam);
+			if (stat == ItemStatModifier::MaxDamage)
+				CalculateDamPercentMod(item, modifiedMaxDam);
+			break;
+		default:
+			break;
+		}
+	}
+
+	switch (stat) {
+	case ItemStatModifier::MinDamage:
+		return modifiedMinDam;
+	case ItemStatModifier::MaxDamage:
+		return modifiedMaxDam;
+	case ItemStatModifier::Armor:
+		return modifiedArmor;
+	}
+}
+
+int CountSetBits(int value)
+{
+	int count = 0;
+	while (value != 0) {
+		if (value & 1)
+			count++;
+		value >>= 1;
+	}
+	return count;
+}
+
+void DrawFloatingItemInfoBox(const Surface &out, Point position)
+{
+	Player &myPlayer = *MyPlayer;
+
+	// Add the lines vector contents into the linesWithColor vector, which contains both the strings and the colors that they will be
+	std::vector<DrawStringFormatArg> linesWithColor;
+
+	// Get which item the cursor is currently over
+	Item &item = pcursinvitem != -1 ? GetInventoryItem(myPlayer, pcursinvitem) : Stash.stashList[pcursstashitem];
+
+	// Add Item Name
+
+	std::string formattedGold;
+	if (item._iClass == ICLASS_GOLD) {
+		int nGold = item._ivalue;
+		formattedGold = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
+		linesWithColor.emplace_back(formattedGold, UiFlags::ColorWhite);
+	} else {
+		if (item._iIdentified && item._iMagical != ITEM_QUALITY_NORMAL) {
+			linesWithColor.emplace_back(item._iIName, item.getTextColor());
+		}
+		linesWithColor.emplace_back(item._iName, item.getTextColor());
+	}
+
+	// Add Item Damage
+	std::string formattedDam;
+	if (item._iClass == ICLASS_WEAPON || item._iMinDam != 0 || item._iMaxDam != 0) {
+		int16_t minDam = CalculateModifiedStatValue(ItemStatModifier::MinDamage, item);
+		int16_t maxDam = CalculateModifiedStatValue(ItemStatModifier::MaxDamage, item);
+		UiFlags damColor = GetItemBonusColors(ItemStatType::Damage, item);
+		linesWithColor.emplace_back(_("Damage:"), UiFlags::ColorWhite);
+
+		if (item._iMinDam == item._iMaxDam) {
+			formattedDam = fmt::format(fmt::runtime(_("{:d}")), minDam);
+			linesWithColor.emplace_back(formattedDam, damColor);
+		} else {
+			formattedDam = fmt::format(fmt::runtime(_("{:d} to {:d}")), minDam, maxDam);
+			linesWithColor.emplace_back(formattedDam, damColor);
+		}
+	}
+
+	// Add Item Armor
+	std::string formattedArmor;
+	if (item._iClass == ICLASS_ARMOR || item._iAC != 0) {
+		int16_t armor = CalculateModifiedStatValue(ItemStatModifier::Armor, item);
+		UiFlags armorColor = GetItemBonusColors(ItemStatType::Armor, item);
+		linesWithColor.emplace_back(_("Armor:"), UiFlags::ColorWhite);
+		formattedArmor = fmt::format(fmt::runtime(_("{:d}")), armor);
+		linesWithColor.emplace_back(formattedArmor, armorColor);
+	}
+
+	// Add Item Durability
+	std::string formattedDur;
+	if (item._iMaxDur != DUR_INDESTRUCTIBLE && (item._iClass == ICLASS_WEAPON || item._iClass == ICLASS_ARMOR)) {
+		UiFlags durColor = GetItemBonusColors(ItemStatType::Durability, item);
+		linesWithColor.emplace_back(_("Durability:"), UiFlags::ColorWhite);
+		formattedDur = fmt::format(fmt::runtime(_("{:d} of {:d}")), item._iDurability, item._iMaxDur);
+		linesWithColor.emplace_back(formattedDur, durColor);
+	}
+
+	// Add Item Requirements
+	if (item._iMinStr > 0) {
+		UiFlags strReqCol = GetItemRequirementColors(ItemRequirementType::Strength, item);
+		linesWithColor.emplace_back(_("Required Strength:"), strReqCol);
+		linesWithColor.emplace_back((_("{:d}"), item._iMinStr), strReqCol);
+	}
+	if (item._iMinDex > 0) {
+		UiFlags dexReqCol = GetItemRequirementColors(ItemRequirementType::Dexterity, item);
+		linesWithColor.emplace_back(_("Required Dexterity:"), dexReqCol);
+		linesWithColor.emplace_back((_("{:d}"), item._iMinDex), dexReqCol);
+	}
+	if (item._iMinMag > 0) {
+		UiFlags magReqCol = GetItemRequirementColors(ItemRequirementType::Magic, item);
+		linesWithColor.emplace_back(_("Required Magic:"), magReqCol);
+		linesWithColor.emplace_back((_("{:d}"), item._iMinMag), magReqCol);
+	}
+
+	// Add Item Identification Status
+	if (!item._iIdentified && item._iMagical) {
+		linesWithColor.emplace_back(_("Not Identified"), UiFlags::ColorRed);
+	}
+
+	// Add Item Charges
+	std::string formattedCharges;
+	if (item._iMaxCharges > 0) {
+		const char *spellName = GetSpellData(item._iSpell).sNameText;
+		formattedCharges = fmt::format("{:s} ({:d}/{:d} Charges)", spellName, item._iCharges, item._iMaxCharges);
+		linesWithColor.emplace_back(formattedCharges, UiFlags::ColorBlue);
+	}
+
+	// Add Magical Item Prefix Power
+	StringOrView prePower;
+	if (item._iPrePower != -1 && item._iIdentified) {
+		prePower = PrintItemPower(item._iPrePower, item);
+		linesWithColor.emplace_back(prePower, UiFlags::ColorBlue);
+	}
+
+	// Add Magical Item Suffix Power
+	StringOrView sufPower;
+	if (item._iSufPower != -1 && item._iIdentified) {
+		sufPower = PrintItemPower(item._iSufPower, item);
+		linesWithColor.emplace_back(sufPower, UiFlags::ColorBlue);
+	}
+
+	// Add Unique Item Powers
+	StringOrView uPower1;
+	StringOrView uPower2;
+	StringOrView uPower3;
+	StringOrView uPower4;
+	StringOrView uPower5;
+	StringOrView uPower6;
+	if (item._iMagical == ITEM_QUALITY_UNIQUE) {
+		const UniqueItem &uitem = UniqueItems[item._iUid];
+		assert(uitem.UINumPL <= sizeof(uitem.powers) / sizeof(*uitem.powers));
+		for (int i = 0; i < uitem.UINumPL; i++) {
+			if (IsAnyOf(uitem.powers[i].type, IPL_INVALID, IPL_INVCURS)) {
+				continue;
+			}
+			switch (i) {
+			case 0:
+				uPower1 = PrintItemPower(uitem.powers[i].type, item);
+				linesWithColor.emplace_back(uPower1, UiFlags::ColorBlue);
+				break;
+			case 1:
+				uPower2 = PrintItemPower(uitem.powers[i].type, item);
+				linesWithColor.emplace_back(uPower2, UiFlags::ColorBlue);
+				break;
+			case 2:
+				uPower3 = PrintItemPower(uitem.powers[i].type, item);
+				linesWithColor.emplace_back(uPower3, UiFlags::ColorBlue);
+				break;
+			case 3:
+				uPower4 = PrintItemPower(uitem.powers[i].type, item);
+				linesWithColor.emplace_back(uPower4, UiFlags::ColorBlue);
+				break;
+			case 4:
+				uPower5 = PrintItemPower(uitem.powers[i].type, item);
+				linesWithColor.emplace_back(uPower5, UiFlags::ColorBlue);
+				break;
+			case 5:
+				uPower6 = PrintItemPower(uitem.powers[i].type, item);
+				linesWithColor.emplace_back(uPower6, UiFlags::ColorBlue);
+				break;
+			}
+		}
+	}
+
+	// Add Item Value
+	std::string formattedValue;
+	if (IsAnyOf(item._iClass, ICLASS_ARMOR, ICLASS_WEAPON, ICLASS_MISC)) {
+		int32_t value = item._iIdentified ? item._iIvalue : item._ivalue;
+		linesWithColor.emplace_back(_("Value:"), UiFlags::ColorWhite);
+		formattedValue = fmt::format(fmt::runtime(_("{:s}")), FormatInteger(value));
+		linesWithColor.emplace_back(formattedValue, UiFlags::ColorWhite);
+	}
+
+	// Add Create Info
+	std::string formattedLevel;
+	std::string formattedSourceOnlyGood;
+	std::string formattedSourceMonster;
+	std::string formattedSourceUnique;
+	std::string formattedSourceDungeon;
+	std::string formattedSourceSmith;
+	std::string formattedSourceSmithPremium;
+	std::string formattedSourceBoy;
+	std::string formattedSourceWitch;
+	std::string formattedSourceHealer;
+	std::string formattedSourcePregen;
+	std::string formattedSourceUnknown;
+	std::string formattedGame;
+	if (extraInfoKeyPressed) {
+		if (item._iClass != ICLASS_GOLD) {
+			// Add Item Level
+			uint8_t level = item._iCreateInfo & CF_LEVEL;
+			if (level != 0) {
+				linesWithColor.emplace_back(_("Level:"), UiFlags::ColorWhite);
+				formattedLevel = fmt::format(fmt::runtime(_("{:d}")), level);
+				linesWithColor.emplace_back(formattedLevel, UiFlags::ColorOrange);
+			}
+
+			// Add Item Source
+
+			std::string source;
+			bool hasSource = false;
+			linesWithColor.emplace_back(_("Source:"), UiFlags::ColorWhite);
+			if (((item._iCreateInfo & CF_ONLYGOOD) != 0) && ((item._iCreateInfo & CF_UPER15) == 0)) {
+				source = _("Armor Rack");
+				formattedSourceOnlyGood = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceOnlyGood, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if ((item._iCreateInfo & CF_UPER1) != 0) {
+				source = _("Dungeon");
+				formattedSourceMonster = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceMonster, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if ((item._iCreateInfo & CF_UPER15) != 0) {
+				source = _("Unique Monster");
+				formattedSourceUnique = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceUnique, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if ((item._iCreateInfo & CF_SMITH) != 0) {
+				source = _("Griswold");
+				formattedSourceSmith = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceSmith, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if ((item._iCreateInfo & CF_SMITHPREMIUM) != 0) {
+				source = _("Griswold Premium");
+				formattedSourceSmithPremium = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceSmithPremium, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if ((item._iCreateInfo & CF_BOY) != 0) {
+				source = _("Wirt");
+				formattedSourceBoy = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceBoy, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if ((item._iCreateInfo & CF_WITCH) != 0) {
+				source = _("Adria");
+				formattedSourceWitch = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceWitch, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if ((item._iCreateInfo & CF_HEALER) != 0) {
+				source = _("Pepin");
+				formattedSourceHealer = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceHealer, UiFlags::ColorOrange);
+				hasSource = true;
+			}
+			if (!hasSource) {
+				source = _("Unknown");
+				formattedSourceUnknown = fmt::format(fmt::runtime(_("{:s}")), source);
+				linesWithColor.emplace_back(formattedSourceUnknown, UiFlags::ColorOrange);
+			}
+
+			// Add Item Game
+			std::string game;
+			linesWithColor.emplace_back(_("Game:"), UiFlags::ColorWhite);
+			if ((item.dwBuff & CF_HELLFIRE) == 0) {
+				game = _("Diablo");
+				formattedGame = fmt::format(fmt::runtime(_("{:s}")), game);
+				linesWithColor.emplace_back(formattedGame, UiFlags::ColorOrange);
+			} else {
+				game = _("Hellfire");
+				formattedGame = fmt::format(fmt::runtime(_("{:s}")), game);
+				linesWithColor.emplace_back(formattedGame, UiFlags::ColorOrange);
+			}
+		}
+	}
+
+	// Add Cheat Item Warning
+	bool isItemLegit = false;
+	string_view illegalItemStr = _("Illegal Item");
+
+	// If the item is sourced from a unique monster, but there are no unique monsters
+	// that have the same level as the item, that means the item was obtained by cheating methods.
+	if ((item._iCreateInfo & CF_UPER15) != 0) {
+		for (int i = 0; UniqueMonstersData[i].mName != nullptr; i++) {
+			const UniqueMonsterData &uniqueMonsterData = UniqueMonstersData[i];
+			const int8_t &uniqueMonsterLevel = MonstersData[uniqueMonsterData.mtype].level;
+			const int8_t itemLevel = item._iCreateInfo & CF_LEVEL;
+
+			if (itemLevel == uniqueMonsterLevel) {
+				isItemLegit = true;
+				break;
+			}
+		}
+
+		if (!isItemLegit) {
+			linesWithColor.emplace_back(illegalItemStr, UiFlags::ColorRed);
+		}
+	}
+
+	// The flags for towner sourced items should never have more than one set at a time.
+	int flagMask = CF_SMITH | CF_SMITHPREMIUM | CF_BOY | CF_WITCH | CF_HEALER;
+	int numFlagsSet = CountSetBits(item._iCreateInfo & flagMask);
+	bool isCompatible = true;
+
+	// Check if either CF_UPER15 or CF_UPER1 is set
+	bool isUper15Set = (item._iCreateInfo & CF_UPER15) != 0;
+	bool isUper1Set = (item._iCreateInfo & CF_UPER1) != 0;
+
+	// Check for compatibility conditions
+	if (isUper15Set || isUper1Set) {
+		if (numFlagsSet > 0)
+			isCompatible = false;
+	} else {
+		if (numFlagsSet > 1)
+			isCompatible = false;
+	}
+
+	if (!isCompatible) {
+		linesWithColor.emplace_back(illegalItemStr, UiFlags::ColorRed);
+	}
+
+	// Items over level 30 cannot exist unless sourced from Wirt, and items over level 50 cannot legally be obtained.
+	if (((item._iCreateInfo & CF_LEVEL) > 30) && ((item._iCreateInfo & CF_BOY) == 0) || ((item._iCreateInfo & CF_LEVEL) > 50) && ((item._iCreateInfo & CF_BOY) != 0)) {
+		linesWithColor.emplace_back(illegalItemStr, UiFlags::ColorRed);
+	}
+
+	// CONSTRUCT STRING AS A BASE FOR UTILIZING LINESWITHCOLOR DATA
+	// linesBase is used to place the {} and newlines to grab the actual string data
+	// Lines that contain a colon may have a different color for the second part, so two {}'s are added
+	std::string linesBase;
+	int totalLinesCount = 0;
+	bool previousLineHadColon = false;
+
+	for (const auto &arg : linesWithColor) {
+		const auto &formatted = arg.GetFormatted();
+		bool currentLineHasColon = !formatted.empty() && formatted.back() == ':';
+
+		if (!previousLineHadColon && (!currentLineHasColon || (!linesBase.empty() && currentLineHasColon))) {
+			if (currentLineHasColon) {
+				linesBase.append("{} {}");
+			} else {
+				linesBase.append("{}");
+			}
+			if (&arg != &linesWithColor.back()) {
+				linesBase.append("\n");
+			}
+			totalLinesCount++;
+		}
+
+		previousLineHadColon = currentLineHasColon;
+	}
+
+	// Adjust the total line count if the last line had a colon
+	if (previousLineHadColon) {
+		totalLinesCount--;
+	}
+
+	// CONSTRUCT AND DRAW TRANSPARENT BOX
+
+	Rectangle infoBoxRect {
+		{ 0, 0 },
+		{ 0, 0 }
+	};
+
+	const int spacing = 4;
+	// GetLineHeight always returns 12 in this function
+	const int lineHeight = 12 + spacing;
+	const Size infoBoxPadding = { 16, 16 };
+
+	int maxWidth = 0;
+	size_t numLines = linesWithColor.size();
+
+	for (size_t i = 0; i < numLines; i++) {
+		const auto &arg = linesWithColor[i];
+		int lineWidth = GetLineWidth(arg.GetFormatted(), GameFontTables::GameFont12, 2);
+
+		if (!arg.GetFormatted().empty() && arg.GetFormatted().back() == ':' && i < numLines - 1) {
+			const auto &nextArg = linesWithColor[i + 1];
+			std::string combinedText = std::string(arg.GetFormatted()) + " " + std::string(nextArg.GetFormatted());
+			// The addition of the infobox padding is a hack; I literally have no clue how to make this work without it.
+			lineWidth = GetLineWidth(combinedText, GameFontTables::GameFont12, 2) + infoBoxPadding.width;
+		}
+
+		maxWidth = std::max(maxWidth, lineWidth);
+	}
+
+	int infoBoxWidth = maxWidth + infoBoxPadding.width;
+
+	Size infoBoxSize {
+		// width of the longest line of text + horizontal padding
+		infoBoxWidth,
+		// the height of the number of lines with spacing + vertical padding
+		(totalLinesCount * lineHeight) + infoBoxPadding.height
+	};
+
+	// Get how many slots the item occupies horizontally and vertically
+	Size itemSize = GetInventorySize(item);
+	// Padding between inventory slots
+	const int invSlotPadding = 1;
+
+	// Define the size and location of the Info Box
+	infoBoxRect = {
+		{ // Render box centered horiztonally
+		    position.x + ((itemSize.width * (INV_SLOT_SIZE_PX + invSlotPadding)) / 2) - (infoBoxSize.width / 2),
+		    // Render box on top of item
+		    position.y - (itemSize.height * (INV_SLOT_SIZE_PX + invSlotPadding)) - infoBoxSize.height },
+		{ infoBoxSize.width,
+		    infoBoxSize.height }
+	};
+
+	// Prevent top screen clipping for items
+	if (infoBoxRect.position.y < 0 && (pcursinvitem != -1 || pcursstashitem != StashStruct::EmptyCell)) {
+		// Display box below item instead of above
+		infoBoxRect.position.y += (itemSize.height * (INV_SLOT_SIZE_PX + invSlotPadding)) + infoBoxSize.height;
+	}
+
+	/* PREVENT CLIPPING */
+	// Prevent top screen clipping
+	if (infoBoxRect.position.y < 0) {
+		infoBoxRect.position.y = 0;
+	}
+	// Prevent right screen clipping
+	if ((infoBoxRect.position.x + infoBoxRect.size.width) > GetScreenWidth())
+		infoBoxRect.position.x -= (infoBoxRect.position.x + infoBoxRect.size.width) - GetScreenWidth();
+	// Prevent left screen clipping
+	if (infoBoxRect.position.x < 0)
+		infoBoxRect.position.x = 0;
+
+	// Draw the transparent box
+	DrawHalfTransparentRectTo(out, infoBoxRect.position.x, infoBoxRect.position.y, infoBoxRect.size.width, infoBoxRect.size.height);
+	DrawHalfTransparentRectTo(out, infoBoxRect.position.x, infoBoxRect.position.y, infoBoxRect.size.width, infoBoxRect.size.height);
+
+	// Adjusting the line height to add spacing between lines
+	// will also add additional space beneath the last line
+	// which throws off the vertical centering
+	infoBoxRect.position.y += infoBoxPadding.height / 2;
+	infoBoxRect.position.y += spacing / 2;
+
+	// FORMAT AND DISPLAY ITEM TEXT OVER TRANSPARENT BOX
+	string_view linesBaseView(linesBase);
+
+	DrawStringWithColors(
+	    out,
+	    linesBaseView,
+	    linesWithColor,
+	    infoBoxRect,
+	    UiFlags::AlignCenter,
+	    2,
+	    lineHeight);
+}
+
+} // namespace devilution

--- a/Source/qol/floatinginfobox.hpp
+++ b/Source/qol/floatinginfobox.hpp
@@ -13,7 +13,6 @@
 
 namespace devilution {
 
-void ExtraInfoKeyPressed(bool pressed);
 void DrawFloatingItemInfoBox(const Surface &out, Point position);
 
 } // namespace devilution

--- a/Source/qol/floatinginfobox.hpp
+++ b/Source/qol/floatinginfobox.hpp
@@ -1,0 +1,19 @@
+/**
+ * @file floatinginfobox.hpp
+ *
+ * Adds floating info box QoL feature
+ */
+#pragma once
+
+#include "engine.h"
+#include "engine/point.hpp"
+#include "engine/surface.hpp"
+#include "items.h"
+#include "utils/enum_traits.h"
+
+namespace devilution {
+
+void ExtraInfoKeyPressed(bool pressed);
+void DrawFloatingItemInfoBox(const Surface &out, Point position);
+
+} // namespace devilution

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -12,6 +12,7 @@
 #include "cursor.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_clx.hpp"
+#include "engine/points_in_rectangle_range.hpp"
 #include "engine/rectangle.hpp"
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -12,7 +12,6 @@
 #include "cursor.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_clx.hpp"
-#include "engine/points_in_rectangle_range.hpp"
 #include "engine/rectangle.hpp"
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
@@ -20,6 +19,7 @@
 #include "hwcursor.hpp"
 #include "inv.h"
 #include "minitext.h"
+#include "qol/floatinginfobox.hpp"
 #include "stores.h"
 #include "utils/format_int.hpp"
 #include "utils/language.h"
@@ -447,10 +447,17 @@ uint16_t CheckStashHLight(Point mousePosition)
 
 	InfoColor = item.getTextColor();
 	InfoString = item.getName();
+
 	if (item._iIdentified) {
-		PrintItemDetails(item);
+		InfoString = string_view(item._iIName);
+		if (!*sgOptions.Gameplay.enableFloatingInfoBox) {
+			PrintItemDetails(item);
+		}
 	} else {
-		PrintItemDur(item);
+		InfoString = string_view(item._iName);
+		if (!*sgOptions.Gameplay.enableFloatingInfoBox) {
+			PrintItemDur(item);
+		}
 	}
 
 	return itemId;

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -12,7 +12,6 @@
 #include "cursor.h"
 #include "engine/clx_sprite.hpp"
 #include "engine/load_clx.hpp"
-#include "engine/points_in_rectangle_range.hpp"
 #include "engine/rectangle.hpp"
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
@@ -22,6 +21,7 @@
 #include "minitext.h"
 #include "qol/floatinginfobox.hpp"
 #include "stores.h"
+#include "string"
 #include "utils/format_int.hpp"
 #include "utils/language.h"
 #include "utils/str_cat.hpp"
@@ -53,9 +53,6 @@ constexpr Rectangle StashButtonRect[] = {
 	{ { 279, 19 }, ButtonSize }  // 10 right
 	// clang-format on
 };
-
-constexpr Size StashGridSize { 10, 10 };
-constexpr PointsInRectangle<int> StashGridRange { { { 0, 0 }, StashGridSize } };
 
 OptionalOwnedClxSpriteList StashPanelArt;
 OptionalOwnedClxSpriteList StashNavButtonArt;
@@ -450,12 +447,12 @@ uint16_t CheckStashHLight(Point mousePosition)
 	InfoString = item.getName();
 
 	if (item._iIdentified) {
-		InfoString = string_view(item._iIName);
+		//InfoString = string_view(item._iIName);
 		if (!*sgOptions.Gameplay.enableFloatingInfoBox) {
 			PrintItemDetails(item);
 		}
 	} else {
-		InfoString = string_view(item._iName);
+		//InfoString = string_view(item._iName);
 		if (!*sgOptions.Gameplay.enableFloatingInfoBox) {
 			PrintItemDur(item);
 		}

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "engine/point.hpp"
+#include "engine/points_in_rectangle_range.hpp"
 #include "items.h"
 
 namespace devilution {
@@ -64,6 +65,10 @@ private:
 	unsigned page;
 };
 
+namespace {
+constexpr Size StashGridSize { 10, 10 };
+constexpr PointsInRectangle<int> StashGridRange { { { 0, 0 }, StashGridSize } };
+}
 constexpr Point InvalidStashPoint { -1, -1 };
 
 extern bool IsStashOpen;

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "engine/point.hpp"
+#include "engine/points_in_rectangle_range.hpp"
 #include "items.h"
 
 namespace devilution {
@@ -64,6 +65,7 @@ private:
 	unsigned page;
 };
 
+constexpr PointsInRectangleRange<int> StashGridRange { { { 0, 0 }, Size { 10, 10 } } };
 constexpr Point InvalidStashPoint { -1, -1 };
 
 extern bool IsStashOpen;

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "engine/point.hpp"
-#include "engine/points_in_rectangle_range.hpp"
 #include "items.h"
 
 namespace devilution {

--- a/Source/qol/stash.h
+++ b/Source/qol/stash.h
@@ -64,7 +64,6 @@ private:
 	unsigned page;
 };
 
-constexpr PointsInRectangleRange<int> StashGridRange { { { 0, 0 }, Size { 10, 10 } } };
 constexpr Point InvalidStashPoint { -1, -1 };
 
 extern bool IsStashOpen;


### PR DESCRIPTION
This PR features a floating info box in the style of Diablo 2. This is the first step towards fully removing the classic control panel and replacing it with one that doesn't have the built-in Info Box.

- Hovering over an inventory/belt/stash item will draw a floating transparent box next to the item, containing all the item data (Will have much more capacity for information than the Control Panel.
- Hovering over Objects will show the name over the object
- Hovering over Monsters will show only the name (More detailed information about monsters can be found on the Health Bar. A new Beastiary Panel will be added containing the information that you would normally find in the Control Panel)

Accidentally overwrote the original PR #2 