### PR TITLE
Item Graphic Colors

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -261,20 +261,10 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 		COL16_GRAY
 	};
 
-	const uint8_t pal8Colors[] = { PAL8_BLUE, PAL8_RED, PAL8_YELLOW, PAL8_ORANGE };
-	const uint8_t pal16Colors[] = { PAL16_BEIGE, PAL16_BLUE, PAL16_YELLOW, PAL16_ORANGE, PAL16_RED, PAL16_GRAY };
-	uint8_t pal8Trn[4];
-	uint8_t pal16Trn[6];
-
-	// Copy values from pal8Trn to pal8Trn
-	for (int i = 0; i < 4; i++) {
-		pal8Trn[i] = pal8Colors[i];
-	}
-
-	// Copy values from pal16Colors to pal16Trn
-	for (int i = 0; i < 6; i++) {
-		pal16Trn[i] = pal16Colors[i];
-	}
+	uint8_t pal8Trn[4] = { PAL8_BLUE, PAL8_RED, PAL8_YELLOW, PAL8_ORANGE };
+	int8_t pal8Brightness[4] = { 0, 0, 0, 0 };
+	uint8_t pal16Trn[6] = { PAL16_BEIGE, PAL16_BLUE, PAL16_YELLOW, PAL16_ORANGE, PAL16_RED, PAL16_GRAY };
+	int8_t pal16Brightness[6] = { 0, 0, 0, 0, 0, 0 };
 
 	if (item._iMagical == ITEM_QUALITY_MAGIC) {
 		switch (item._iPrePower) {
@@ -283,14 +273,15 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 		case IPL_TOHIT_CURSE:
 			break;
 		case IPL_DAMP:
-			pal16Trn[COL16_BLUE] = pal16Colors[COL16_RED] - 1;
+			pal16Trn[COL16_BLUE] = PAL16_RED;
+			pal16Brightness[COL16_BLUE] = -1;
 			break;
 		case IPL_DAMP_CURSE:
 			break;
 		case IPL_DOPPELGANGER:
 			break;
 		case IPL_TOHIT_DAMP:
-			pal16Trn[COL16_BLUE] = pal16Colors[COL16_RED];
+			pal16Trn[COL16_BLUE] = PAL16_RED;
 			break;
 		case IPL_TOHIT_DAMP_CURSE:
 			break;
@@ -307,9 +298,10 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 		case IPL_MAGICRES:
 			break;
 		case IPL_ALLRES:
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 2;
-			pal16Trn[COL16_BLUE] = pal16Colors[COL16_GRAY] + 2;
-			pal16Trn[COL16_YELLOW] = pal16Colors[COL16_RED];
+			pal16Brightness[COL16_GRAY] = 2;
+			pal16Trn[COL16_BLUE] = PAL16_GRAY;
+			pal16Brightness[COL16_BLUE] = 2;
+			pal16Trn[COL16_YELLOW] = PAL16_RED;
 			break;
 		case IPL_SPLLVLADD:
 			break;
@@ -321,8 +313,10 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 			break;
 		case IPL_MANA:
 		case IPL_MANA_CURSE:
-			pal16Trn[COL16_BLUE] = pal16Colors[COL16_BLUE] + 1;
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_BLUE] + 1;
+			pal16Trn[COL16_BLUE] = PAL16_BLUE;
+			pal16Brightness[COL16_BLUE] = 1;
+			pal16Trn[COL16_GRAY] = PAL16_BLUE;
+			pal16Brightness[COL16_GRAY] = 1;
 			break;
 		case IPL_CRYSTALLINE:
 			break;
@@ -335,24 +329,28 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 			break;
 		case IPL_STR:
 		case IPL_STR_CURSE:
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_BLUE] - 1;
+			pal16Trn[COL16_GRAY] = PAL16_BLUE;
+			pal16Brightness[COL16_GRAY] = -1;
 			break;
 		case IPL_MAG:
 		case IPL_MAG_CURSE:
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_ORANGE] - 1;
+			pal16Trn[COL16_GRAY] = PAL16_ORANGE;
+			pal16Brightness[COL16_GRAY] = -1;
 			break;
 		case IPL_DEX:
 		case IPL_DEX_CURSE:
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 2;
+			pal16Trn[COL16_GRAY] = PAL16_GRAY;
+			pal16Brightness[COL16_GRAY] = 2;
 			break;
 		case IPL_VIT:
 		case IPL_VIT_CURSE:
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] - 1;
+			pal16Trn[COL16_GRAY] = PAL16_GRAY;
+			pal16Brightness[COL16_GRAY] = -1;
 			break;
 		case IPL_ATTRIBS:
 		case IPL_ATTRIBS_CURSE:
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_YELLOW];
-			pal16Trn[COL16_YELLOW] = pal16Colors[COL16_GRAY];
+			pal16Trn[COL16_GRAY] = PAL16_YELLOW;
+			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
 			break;
 		case IPL_GETHIT_CURSE:
 			break;
@@ -391,8 +389,9 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 		case IPL_TARGAC:
 			break;
 		case IPL_FASTATTACK:
-			pal16Trn[COL16_YELLOW] = pal16Colors[COL16_GRAY] + 1;
-			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 3;
+			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+			pal16Brightness[COL16_YELLOW] = 1;
+			pal16Brightness[COL16_GRAY] = 3;
 			break;
 		case IPL_FASTRECOVER:
 			break;
@@ -415,13 +414,14 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 
 	switch (item._iUid) {
 	case 68:
-		pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 2;
-		pal16Trn[COL16_YELLOW] = pal16Colors[COL16_RED];
-		pal16Trn[COL16_BLUE] = pal16Colors[COL16_GRAY] + 2;
+		pal16Brightness[COL16_GRAY] = 2;
+		pal16Trn[COL16_YELLOW] = PAL16_RED;
+		pal16Trn[COL16_BLUE] = PAL16_GRAY;
+		pal16Brightness[COL16_GRAY] = 2;
 	}
 
 	if (usable) {
-		ClxDrawTRN(out, position, clx, GetCustomTRN(pal8Trn[COL8_BLUE], pal8Trn[COL8_RED], pal8Trn[COL8_YELLOW], pal8Trn[COL8_ORANGE], pal16Trn[COL16_BEIGE], pal16Trn[COL16_BLUE], pal16Trn[COL16_YELLOW], pal16Trn[COL16_ORANGE], pal16Trn[COL16_RED], pal16Trn[COL16_GRAY]));
+		ClxDrawTRN(out, position, clx, GetCustomTRN(pal8Trn[COL8_BLUE], pal8Brightness[COL8_BLUE], pal8Trn[COL8_RED], pal8Brightness[COL8_RED], pal8Trn[COL8_YELLOW], pal8Brightness[COL8_YELLOW], pal8Trn[COL8_ORANGE], pal8Brightness[COL8_ORANGE], pal16Trn[COL16_BEIGE], pal16Brightness[COL16_BEIGE], pal16Trn[COL16_BLUE], pal16Brightness[COL16_BLUE], pal16Trn[COL16_YELLOW], pal16Brightness[COL16_YELLOW], pal16Trn[COL16_ORANGE], pal16Brightness[COL16_ORANGE], pal16Trn[COL16_RED], pal16Brightness[COL16_RED], pal16Trn[COL16_GRAY], pal16Brightness[COL16_GRAY]));
 	} else {
 		ClxDrawTRN(out, position, clx, GetInfravisionTRN());
 	}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -262,112 +262,39 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 	};
 
 	uint8_t pal8Trn[4] = { PAL8_BLUE, PAL8_RED, PAL8_YELLOW, PAL8_ORANGE };
-	int8_t pal8Brightness[4] = { 0, 0, 0, 0 };
+	int8_t pal8Dimming[4] = { 0, 0, 0, 0 };
 	uint8_t pal16Trn[6] = { PAL16_BEIGE, PAL16_BLUE, PAL16_YELLOW, PAL16_ORANGE, PAL16_RED, PAL16_GRAY };
-	int8_t pal16Brightness[6] = { 0, 0, 0, 0, 0, 0 };
+	int8_t pal16Dimming[6] = { 0, 0, 0, 0, 0, 0 };
 
 	if (item._iMagical == ITEM_QUALITY_MAGIC) {
-		switch (item._iPrePower) {
-		case IPL_TOHIT:
-			break;
-		case IPL_TOHIT_CURSE:
-			break;
-		case IPL_DAMP:
-			pal16Trn[COL16_BLUE] = PAL16_RED;
-			pal16Brightness[COL16_BLUE] = -1;
-			break;
-		case IPL_DAMP_CURSE:
-			break;
-		case IPL_DOPPELGANGER:
-			break;
-		case IPL_TOHIT_DAMP:
-			pal16Trn[COL16_BLUE] = PAL16_RED;
-			break;
-		case IPL_TOHIT_DAMP_CURSE:
-			break;
-		case IPL_ACP:
-			break;
-		case IPL_ACP_CURSE:
-			break;
-		case IPL_AC_CURSE:
-			break;
-		case IPL_FIRERES:
-			break;
-		case IPL_LIGHTRES:
-			break;
-		case IPL_MAGICRES:
-			break;
-		case IPL_ALLRES:
-			pal16Brightness[COL16_GRAY] = 2;
-			pal16Trn[COL16_BLUE] = PAL16_GRAY;
-			pal16Brightness[COL16_BLUE] = 2;
-			pal16Trn[COL16_YELLOW] = PAL16_RED;
-			break;
-		case IPL_SPLLVLADD:
-			break;
-		case IPL_CHARGES:
-			break;
-		case IPL_FIREDAM:
-			break;
-		case IPL_LIGHTDAM:
-			break;
-		case IPL_MANA:
-		case IPL_MANA_CURSE:
-			pal16Trn[COL16_BLUE] = PAL16_BLUE;
-			pal16Brightness[COL16_BLUE] = 1;
-			pal16Trn[COL16_GRAY] = PAL16_BLUE;
-			pal16Brightness[COL16_GRAY] = 1;
-			break;
-		case IPL_CRYSTALLINE:
-			break;
-		default:
-			break;
-		}
-
 		switch (item._iSufPower) {
-		case IPL_SPELL:
-			break;
 		case IPL_STR:
 		case IPL_STR_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_BLUE;
-			pal16Brightness[COL16_GRAY] = -1;
 			break;
 		case IPL_MAG:
 		case IPL_MAG_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_ORANGE;
-			pal16Brightness[COL16_GRAY] = -1;
 			break;
 		case IPL_DEX:
 		case IPL_DEX_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_GRAY;
-			pal16Brightness[COL16_GRAY] = 2;
 			break;
 		case IPL_VIT:
 		case IPL_VIT_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_GRAY;
-			pal16Brightness[COL16_GRAY] = -1;
 			break;
 		case IPL_ATTRIBS:
 		case IPL_ATTRIBS_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_YELLOW;
-			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
-			break;
-		case IPL_GETHIT_CURSE:
 			break;
 		case IPL_GETHIT:
+		case IPL_GETHIT_CURSE:
 			break;
 		case IPL_LIFE:
-			break;
 		case IPL_LIFE_CURSE:
 			break;
 		case IPL_DUR:
-			break;
 		case IPL_DUR_CURSE:
 			break;
 		case IPL_INDESTRUCTIBLE:
 			break;
 		case IPL_LIGHT:
-			break;
 		case IPL_LIGHT_CURSE:
 			break;
 		case IPL_FIRE_ARROWS:
@@ -389,9 +316,6 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 		case IPL_TARGAC:
 			break;
 		case IPL_FASTATTACK:
-			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
-			pal16Brightness[COL16_YELLOW] = 1;
-			pal16Brightness[COL16_GRAY] = 3;
 			break;
 		case IPL_FASTRECOVER:
 			break;
@@ -410,21 +334,116 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 		default:
 			break;
 		}
+
+		switch (item._iPrePower) {
+		case IPL_TOHIT:
+		case IPL_TOHIT_CURSE:
+			pal16Trn[COL16_GRAY] = PAL16_YELLOW;
+			pal16Dimming[COL16_GRAY] = -1;
+			pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
+			pal16Dimming[COL16_YELLOW] = 0;
+			break;
+		case IPL_DAMP:
+		case IPL_DAMP_CURSE:
+			pal16Trn[COL16_GRAY] = PAL16_RED;
+			pal16Dimming[COL16_GRAY] = -1;
+			pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
+			pal16Dimming[COL16_YELLOW] = 2;
+			break;
+		case IPL_DOPPELGANGER:
+			break;
+		case IPL_TOHIT_DAMP:
+		case IPL_TOHIT_DAMP_CURSE:
+			pal16Trn[COL16_GRAY] = PAL16_ORANGE;
+			pal16Dimming[COL16_GRAY] = -1;
+			pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
+			pal16Dimming[COL16_YELLOW] = 2;
+			break;
+		case IPL_ACP:
+		case IPL_ACP_CURSE:
+			pal16Trn[COL16_GRAY] = PAL16_GRAY;
+			pal16Dimming[COL16_GRAY] = 2;
+			pal16Trn[COL16_YELLOW] = PAL16_RED;
+			pal16Dimming[COL16_YELLOW] = 1;
+			break;
+		case IPL_FIRERES:
+			pal16Trn[COL16_GRAY] = PAL16_RED;
+			pal16Dimming[COL16_GRAY] = 0;
+			pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+			pal16Dimming[COL16_YELLOW] = 0;
+			break;
+		case IPL_LIGHTRES:
+			pal16Trn[COL16_GRAY] = PAL16_BLUE;
+			pal16Dimming[COL16_GRAY] = 0;
+			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+			pal16Dimming[COL16_YELLOW] = 0;
+			break;
+		case IPL_MAGICRES:
+			pal16Trn[COL16_GRAY] = PAL16_GRAY;
+			pal16Dimming[COL16_GRAY] = -2;
+			pal16Trn[COL16_YELLOW] = PAL16_BLUE;
+			pal16Dimming[COL16_YELLOW] = -2;
+			break;
+		case IPL_ALLRES:
+			pal16Trn[COL16_GRAY] = PAL16_GRAY;
+			pal16Dimming[COL16_GRAY] = 1;
+			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+			pal16Dimming[COL16_YELLOW] = 2;
+			break;
+		case IPL_SPLLVLADD:
+			pal16Trn[COL16_GRAY] = PAL16_BLUE;
+			pal16Dimming[COL16_GRAY] = -2;
+			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+			pal16Dimming[COL16_YELLOW] = -2;
+			break;
+		case IPL_CHARGES:
+			pal16Trn[COL16_GRAY] = PAL16_GRAY;
+			pal16Dimming[COL16_GRAY] = -1;
+			pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+			pal16Dimming[COL16_YELLOW] = 0;
+			break;
+		case IPL_FIREDAM:
+			pal16Trn[COL16_GRAY] = PAL16_RED;
+			pal16Dimming[COL16_GRAY] = 1;
+			pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+			pal16Dimming[COL16_YELLOW] = 1;
+			break;
+		case IPL_LIGHTDAM:
+			pal16Trn[COL16_GRAY] = PAL16_BLUE;
+			pal16Dimming[COL16_GRAY] = 1;
+			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+			pal16Dimming[COL16_YELLOW] = 1;
+			break;
+		case IPL_MANA:
+		case IPL_MANA_CURSE:
+			pal16Trn[COL16_GRAY] = PAL16_BLUE;
+			pal16Dimming[COL16_GRAY] = 2;
+			pal16Trn[COL16_YELLOW] = PAL16_BLUE;
+			pal16Dimming[COL16_YELLOW] = 0;
+			break;
+		case IPL_CRYSTALLINE:
+			break;
+		default:
+			break;
+		}
 	}
 
-	switch (item._iUid) {
-	case 68:
-		pal16Brightness[COL16_GRAY] = 2;
-		pal16Trn[COL16_YELLOW] = PAL16_RED;
-		pal16Trn[COL16_BLUE] = PAL16_GRAY;
-		pal16Brightness[COL16_GRAY] = 2;
-	}
+	//if (item._iSpell != SpellID::Invalid)
+	//	pal16Trn[COL16_RED] = PAL16_ORANGE;
 
-	if (usable) {
-		ClxDrawTRN(out, position, clx, GetCustomTRN(pal8Trn[COL8_BLUE], pal8Brightness[COL8_BLUE], pal8Trn[COL8_RED], pal8Brightness[COL8_RED], pal8Trn[COL8_YELLOW], pal8Brightness[COL8_YELLOW], pal8Trn[COL8_ORANGE], pal8Brightness[COL8_ORANGE], pal16Trn[COL16_BEIGE], pal16Brightness[COL16_BEIGE], pal16Trn[COL16_BLUE], pal16Brightness[COL16_BLUE], pal16Trn[COL16_YELLOW], pal16Brightness[COL16_YELLOW], pal16Trn[COL16_ORANGE], pal16Brightness[COL16_ORANGE], pal16Trn[COL16_RED], pal16Brightness[COL16_RED], pal16Trn[COL16_GRAY], pal16Brightness[COL16_GRAY]));
-	} else {
-		ClxDrawTRN(out, position, clx, GetInfravisionTRN());
-	}
+	//switch (item._iUid) {
+	//case 68:
+	//	pal16Dimming[COL16_GRAY] = 2;
+	//	pal16Trn[COL16_YELLOW] = PAL16_RED;
+	//	pal16Trn[COL16_BLUE] = PAL16_GRAY;
+	//	pal16Dimming[COL16_GRAY] = 2;
+	//}
+
+	//if (usable) {
+		ClxDrawTRN(out, position, clx, GetCustomTRN(pal8Trn[COL8_BLUE], pal8Dimming[COL8_BLUE], pal8Trn[COL8_RED], pal8Dimming[COL8_RED], pal8Trn[COL8_YELLOW], pal8Dimming[COL8_YELLOW], pal8Trn[COL8_ORANGE], pal8Dimming[COL8_ORANGE], pal16Trn[COL16_BEIGE], pal16Dimming[COL16_BEIGE], pal16Trn[COL16_BLUE], pal16Dimming[COL16_BLUE], pal16Trn[COL16_YELLOW], pal16Dimming[COL16_YELLOW], pal16Trn[COL16_ORANGE], pal16Dimming[COL16_ORANGE], pal16Trn[COL16_RED], pal16Dimming[COL16_RED], pal16Trn[COL16_GRAY], pal16Dimming[COL16_GRAY]));
+	//} else {
+	//	ClxDrawTRN(out, position, clx, GetInfravisionTRN());
+	//}
 }
 
 void ResetCursor()

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -270,160 +270,614 @@ void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite cl
 		switch (item._iSufPower) {
 		case IPL_STR:
 		case IPL_STR_CURSE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_MAG:
 		case IPL_MAG_CURSE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_DEX:
 		case IPL_DEX_CURSE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_VIT:
 		case IPL_VIT_CURSE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_ATTRIBS:
 		case IPL_ATTRIBS_CURSE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_GETHIT:
 		case IPL_GETHIT_CURSE:
+			switch (item._iClass) {
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_LIFE:
 		case IPL_LIFE_CURSE:
+			switch (item._iClass) {
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_DUR:
 		case IPL_DUR_CURSE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_INDESTRUCTIBLE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_LIGHT:
 		case IPL_LIGHT_CURSE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_FIRE_ARROWS:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_LIGHT_ARROWS:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_THORNS:
+			switch (item._iClass) {
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_NOMANA:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_ABSHALFTRAP:
+			switch (item._iClass) {
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_KNOCKBACK:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_STEALMANA:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_STEALLIFE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_TARGAC:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_FASTATTACK:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_FASTRECOVER:
+			switch (item._iClass) {
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_FASTBLOCK:
+			switch (item._iClass) {
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_DAMMOD:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_DEVASTATION:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_DECAY:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_PERIL:
-			break;
-		case IPL_JESTERS:
-			break;
-		default:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		}
 
 		switch (item._iPrePower) {
 		case IPL_TOHIT:
 		case IPL_TOHIT_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_YELLOW;
-			pal16Dimming[COL16_GRAY] = -1;
-			pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
-			pal16Dimming[COL16_YELLOW] = 0;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_YELLOW;
+				pal16Dimming[COL16_GRAY] = -1;
+				pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_YELLOW;
+				pal16Dimming[COL16_GRAY] = -1;
+				pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			}
 			break;
 		case IPL_DAMP:
 		case IPL_DAMP_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_RED;
-			pal16Dimming[COL16_GRAY] = -1;
-			pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
-			pal16Dimming[COL16_YELLOW] = 2;
-			break;
-		case IPL_DOPPELGANGER:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_RED;
+				pal16Dimming[COL16_GRAY] = -1;
+				pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
+				pal16Dimming[COL16_YELLOW] = 2;
+				break;
+			}
 			break;
 		case IPL_TOHIT_DAMP:
 		case IPL_TOHIT_DAMP_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_ORANGE;
-			pal16Dimming[COL16_GRAY] = -1;
-			pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
-			pal16Dimming[COL16_YELLOW] = 2;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_ORANGE;
+				pal16Dimming[COL16_GRAY] = -1;
+				pal16Trn[COL16_YELLOW] = PAL16_BEIGE;
+				pal16Dimming[COL16_YELLOW] = 2;
+				break;
+			}
 			break;
 		case IPL_ACP:
 		case IPL_ACP_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_GRAY;
-			pal16Dimming[COL16_GRAY] = 2;
-			pal16Trn[COL16_YELLOW] = PAL16_RED;
-			pal16Dimming[COL16_YELLOW] = 1;
+			switch (item._iClass) {
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 2;
+				pal16Trn[COL16_YELLOW] = PAL16_RED;
+				pal16Dimming[COL16_YELLOW] = 1;
+				break;
+			}
 			break;
 		case IPL_FIRERES:
-			pal16Trn[COL16_GRAY] = PAL16_RED;
-			pal16Dimming[COL16_GRAY] = 0;
-			pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
-			pal16Dimming[COL16_YELLOW] = 0;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_RED;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_RED;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_RED;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			}
 			break;
 		case IPL_LIGHTRES:
-			pal16Trn[COL16_GRAY] = PAL16_BLUE;
-			pal16Dimming[COL16_GRAY] = 0;
-			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
-			pal16Dimming[COL16_YELLOW] = 0;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_BLUE;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_BLUE;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_BLUE;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			}
 			break;
 		case IPL_MAGICRES:
-			pal16Trn[COL16_GRAY] = PAL16_GRAY;
-			pal16Dimming[COL16_GRAY] = -2;
-			pal16Trn[COL16_YELLOW] = PAL16_BLUE;
-			pal16Dimming[COL16_YELLOW] = -2;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = -2;
+				pal16Trn[COL16_YELLOW] = PAL16_BLUE;
+				pal16Dimming[COL16_YELLOW] = -2;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = -2;
+				pal16Trn[COL16_YELLOW] = PAL16_BLUE;
+				pal16Dimming[COL16_YELLOW] = -2;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = -2;
+				pal16Trn[COL16_YELLOW] = PAL16_BLUE;
+				pal16Dimming[COL16_YELLOW] = -2;
+				break;
+			}
 			break;
 		case IPL_ALLRES:
-			pal16Trn[COL16_GRAY] = PAL16_GRAY;
-			pal16Dimming[COL16_GRAY] = 1;
-			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
-			pal16Dimming[COL16_YELLOW] = 2;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 1;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = 2;
+				break;
+			case ICLASS_ARMOR:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 1;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = 2;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 1;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = 2;
+				break;
+			}
 			break;
 		case IPL_SPLLVLADD:
-			pal16Trn[COL16_GRAY] = PAL16_BLUE;
-			pal16Dimming[COL16_GRAY] = -2;
-			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
-			pal16Dimming[COL16_YELLOW] = -2;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_BLUE;
+				pal16Dimming[COL16_GRAY] = -2;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = -2;
+				break;
+			}
 			break;
 		case IPL_CHARGES:
-			pal16Trn[COL16_GRAY] = PAL16_GRAY;
-			pal16Dimming[COL16_GRAY] = -1;
-			pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
-			pal16Dimming[COL16_YELLOW] = 0;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = -1;
+				pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			}
 			break;
 		case IPL_FIREDAM:
-			pal16Trn[COL16_GRAY] = PAL16_RED;
-			pal16Dimming[COL16_GRAY] = 1;
-			pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
-			pal16Dimming[COL16_YELLOW] = 1;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_RED;
+				pal16Dimming[COL16_GRAY] = 1;
+				pal16Trn[COL16_YELLOW] = PAL16_ORANGE;
+				pal16Dimming[COL16_YELLOW] = 1;
+				break;
+			}
 			break;
 		case IPL_LIGHTDAM:
-			pal16Trn[COL16_GRAY] = PAL16_BLUE;
-			pal16Dimming[COL16_GRAY] = 1;
-			pal16Trn[COL16_YELLOW] = PAL16_GRAY;
-			pal16Dimming[COL16_YELLOW] = 1;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_BLUE;
+				pal16Dimming[COL16_GRAY] = 1;
+				pal16Trn[COL16_YELLOW] = PAL16_GRAY;
+				pal16Dimming[COL16_YELLOW] = 1;
+				break;
+			}
 			break;
 		case IPL_MANA:
 		case IPL_MANA_CURSE:
-			pal16Trn[COL16_GRAY] = PAL16_BLUE;
-			pal16Dimming[COL16_GRAY] = 2;
-			pal16Trn[COL16_YELLOW] = PAL16_BLUE;
-			pal16Dimming[COL16_YELLOW] = 0;
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_BLUE;
+				pal16Dimming[COL16_GRAY] = 2;
+				pal16Trn[COL16_YELLOW] = PAL16_BLUE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			case ICLASS_MISC:
+				pal16Trn[COL16_GRAY] = PAL16_BLUE;
+				pal16Dimming[COL16_GRAY] = 2;
+				pal16Trn[COL16_YELLOW] = PAL16_BLUE;
+				pal16Dimming[COL16_YELLOW] = 0;
+				break;
+			}
+			break;
+		case IPL_DOPPELGANGER:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		case IPL_CRYSTALLINE:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
-		default:
+		case IPL_JESTERS:
+			switch (item._iClass) {
+			case ICLASS_WEAPON:
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				pal16Trn[COL16_GRAY] = PAL16_GRAY;
+				pal16Dimming[COL16_GRAY] = 0;
+				break;
+			}
 			break;
 		}
 	}

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -244,8 +244,184 @@ void FreeHalfSizeItemSprites()
 void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite clx)
 {
 	const bool usable = item._iStatFlag;
+
+	enum color8 : uint8_t {
+		COL8_BLUE,
+		COL8_RED,
+		COL8_YELLOW,
+		COL8_ORANGE
+	};
+
+	enum color16 : uint8_t {
+		COL16_BEIGE,
+		COL16_BLUE,
+		COL16_YELLOW,
+		COL16_ORANGE,
+		COL16_RED,
+		COL16_GRAY
+	};
+
+	const uint8_t pal8Colors[] = { PAL8_BLUE, PAL8_RED, PAL8_YELLOW, PAL8_ORANGE };
+	const uint8_t pal16Colors[] = { PAL16_BEIGE, PAL16_BLUE, PAL16_YELLOW, PAL16_ORANGE, PAL16_RED, PAL16_GRAY };
+	uint8_t pal8Trn[4];
+	uint8_t pal16Trn[6];
+
+	// Copy values from pal8Trn to pal8Trn
+	for (int i = 0; i < 4; i++) {
+		pal8Trn[i] = pal8Colors[i];
+	}
+
+	// Copy values from pal16Colors to pal16Trn
+	for (int i = 0; i < 6; i++) {
+		pal16Trn[i] = pal16Colors[i];
+	}
+
+	if (item._iMagical == ITEM_QUALITY_MAGIC) {
+		switch (item._iPrePower) {
+		case IPL_TOHIT:
+			break;
+		case IPL_TOHIT_CURSE:
+			break;
+		case IPL_DAMP:
+			pal16Trn[COL16_BLUE] = pal16Colors[COL16_RED] - 1;
+			break;
+		case IPL_DAMP_CURSE:
+			break;
+		case IPL_DOPPELGANGER:
+			break;
+		case IPL_TOHIT_DAMP:
+			pal16Trn[COL16_BLUE] = pal16Colors[COL16_RED];
+			break;
+		case IPL_TOHIT_DAMP_CURSE:
+			break;
+		case IPL_ACP:
+			break;
+		case IPL_ACP_CURSE:
+			break;
+		case IPL_AC_CURSE:
+			break;
+		case IPL_FIRERES:
+			break;
+		case IPL_LIGHTRES:
+			break;
+		case IPL_MAGICRES:
+			break;
+		case IPL_ALLRES:
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 2;
+			pal16Trn[COL16_BLUE] = pal16Colors[COL16_GRAY] + 2;
+			pal16Trn[COL16_YELLOW] = pal16Colors[COL16_RED];
+			break;
+		case IPL_SPLLVLADD:
+			break;
+		case IPL_CHARGES:
+			break;
+		case IPL_FIREDAM:
+			break;
+		case IPL_LIGHTDAM:
+			break;
+		case IPL_MANA:
+		case IPL_MANA_CURSE:
+			pal16Trn[COL16_BLUE] = pal16Colors[COL16_BLUE] + 1;
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_BLUE] + 1;
+			break;
+		case IPL_CRYSTALLINE:
+			break;
+		default:
+			break;
+		}
+
+		switch (item._iSufPower) {
+		case IPL_SPELL:
+			break;
+		case IPL_STR:
+		case IPL_STR_CURSE:
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_BLUE] - 1;
+			break;
+		case IPL_MAG:
+		case IPL_MAG_CURSE:
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_ORANGE] - 1;
+			break;
+		case IPL_DEX:
+		case IPL_DEX_CURSE:
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 2;
+			break;
+		case IPL_VIT:
+		case IPL_VIT_CURSE:
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] - 1;
+			break;
+		case IPL_ATTRIBS:
+		case IPL_ATTRIBS_CURSE:
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_YELLOW];
+			pal16Trn[COL16_YELLOW] = pal16Colors[COL16_GRAY];
+			break;
+		case IPL_GETHIT_CURSE:
+			break;
+		case IPL_GETHIT:
+			break;
+		case IPL_LIFE:
+			break;
+		case IPL_LIFE_CURSE:
+			break;
+		case IPL_DUR:
+			break;
+		case IPL_DUR_CURSE:
+			break;
+		case IPL_INDESTRUCTIBLE:
+			break;
+		case IPL_LIGHT:
+			break;
+		case IPL_LIGHT_CURSE:
+			break;
+		case IPL_FIRE_ARROWS:
+			break;
+		case IPL_LIGHT_ARROWS:
+			break;
+		case IPL_THORNS:
+			break;
+		case IPL_NOMANA:
+			break;
+		case IPL_ABSHALFTRAP:
+			break;
+		case IPL_KNOCKBACK:
+			break;
+		case IPL_STEALMANA:
+			break;
+		case IPL_STEALLIFE:
+			break;
+		case IPL_TARGAC:
+			break;
+		case IPL_FASTATTACK:
+			pal16Trn[COL16_YELLOW] = pal16Colors[COL16_GRAY] + 1;
+			pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 3;
+			break;
+		case IPL_FASTRECOVER:
+			break;
+		case IPL_FASTBLOCK:
+			break;
+		case IPL_DAMMOD:
+			break;
+		case IPL_DEVASTATION:
+			break;
+		case IPL_DECAY:
+			break;
+		case IPL_PERIL:
+			break;
+		case IPL_JESTERS:
+			break;
+		default:
+			break;
+		}
+	}
+
+	switch (item._iUid) {
+	case 68:
+		pal16Trn[COL16_GRAY] = pal16Colors[COL16_GRAY] + 2;
+		pal16Trn[COL16_YELLOW] = pal16Colors[COL16_RED];
+		pal16Trn[COL16_BLUE] = pal16Colors[COL16_GRAY] + 2;
+	}
+
 	if (usable) {
-		ClxDraw(out, position, clx);
+		ClxDrawTRN(out, position, clx, GetCustomTRN(pal8Trn[COL8_BLUE], pal8Trn[COL8_RED], pal8Trn[COL8_YELLOW], pal8Trn[COL8_ORANGE], pal16Trn[COL16_BEIGE], pal16Trn[COL16_BLUE], pal16Trn[COL16_YELLOW], pal16Trn[COL16_ORANGE], pal16Trn[COL16_RED], pal16Trn[COL16_GRAY]));
 	} else {
 		ClxDrawTRN(out, position, clx, GetInfravisionTRN());
 	}

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -10,87 +10,104 @@
 
 namespace devilution {
 
-uint8_t *GetCustomTRN(uint8_t pal8blue, uint8_t pal8red, uint8_t pal8yellow, uint8_t pal8orange, uint8_t pal16beige, uint8_t pal16blue, uint8_t pal16yellow, uint8_t pal16orange, uint8_t pal16red, uint8_t pal16gray)
+uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8red, int8_t pal8redBrightness, uint8_t pal8yellow, int8_t pal8yellowBrightness, uint8_t pal8orange, int8_t pal8orangeBrightness, uint8_t pal16beige, int8_t pal16beigeBrightness, uint8_t pal16blue, int8_t pal16blueBrightness, uint8_t pal16yellow, int8_t pal16yellowBrightness, uint8_t pal16orange, int8_t pal16orangeBrightness, uint8_t pal16red, int8_t pal16redBrightness, uint8_t pal16gray, int8_t pal16grayBrightness )
 {
 	std::unique_ptr<uint8_t[]> customTrn(new uint8_t[256]);
+	// Remaining colors on each line of colors after the first index
+	int pal8colors = 8;
+	int pal16colors = 16;
 
 	// Fill town/dungeon palette as default
-	for (uint8_t i = 0; i < 128; i++) {
+	for (int i = 0; i < 128; i++) {
 		customTrn[i] = i;
 	}
 
-	for (uint8_t i = PAL8_BLUE; i < PAL8_RED; i++) {
-		customTrn[i] = i - PAL8_BLUE + pal8blue;
+	// Fill PAL8_BLUE indices
+	for (int i = PAL8_BLUE; i < PAL8_RED; i++) {
+		int value = i - PAL8_BLUE;
+		value += pal8blue;
+		value += pal8blueBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal8blue), pal8blue + pal8colors - 1);
 	}
 
-	for (uint8_t i = PAL8_RED; i < PAL8_YELLOW; i++) {
-		customTrn[i] = i - PAL8_RED + pal8red;
+	// Fill PAL8_RED indices
+	for (int i = PAL8_RED; i < PAL8_YELLOW; i++) {
+		int value = i - PAL8_RED;
+		value += pal8red;
+		value += pal8redBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal8red), pal8red + pal8colors - 1);
 	}
 
-	for (uint8_t i = PAL8_YELLOW; i < PAL8_ORANGE; i++) {
-		customTrn[i] = i - PAL8_YELLOW + pal8yellow;
+	// Fill PAL8_YELLOW indices
+	for (int i = PAL8_YELLOW; i < PAL8_ORANGE; i++) {
+		int value = i - PAL8_YELLOW;
+		value += pal8yellow;
+		value += pal8yellowBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal8yellow), pal8yellow + pal8colors - 1);
 	}
 
-	for (uint8_t i = PAL8_ORANGE; i < PAL16_BEIGE; i++) {
-		customTrn[i] = i - PAL8_ORANGE + pal8orange;
+	// Fill PAL8_ORANGE indices
+	for (int i = PAL8_ORANGE; i < PAL16_BEIGE; i++) {
+		int value = i - PAL8_ORANGE;
+		value += pal8orange;
+		value += pal8orangeBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal8orange), pal8orange + pal8colors - 1);
 	}
 
-	for (uint8_t i = PAL16_BEIGE; i < PAL16_BLUE; i++) {
-		uint8_t adj = 0;
-		if ((i == PAL16_BEIGE) && (pal16beige % 16 != 0))
-			adj = 1;
-		int value = i - PAL16_BEIGE + pal16beige + adj;
-		value = std::clamp(value, 0, 254);
-		customTrn[i] = static_cast<uint8_t>(value);
+	// Fill PAL16_BEIGE indices
+	for (int i = PAL16_BEIGE; i < PAL16_BLUE; i++) {
+		int value = i - PAL16_BEIGE;
+		value += pal16beige;
+		value += pal16beigeBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal16beige), pal16beige + pal16colors - 1);
 	}
 
-	for (uint8_t i = PAL16_BLUE; i < PAL16_YELLOW; i++) {
-		uint8_t adj = 0;
-		if ((i == PAL16_BLUE) && (pal16blue % 16 != 0))
-			adj = 1;
-		int value = i - PAL16_BLUE + pal16blue + adj;
-		value = std::clamp(value, 0, 254);
-		customTrn[i] = static_cast<uint8_t>(value);
+	// Fill PAL16_BLUE indices
+	for (int i = PAL16_BLUE; i < PAL16_YELLOW; i++) {
+		int value = i - PAL16_BLUE;
+		value += pal16blue;
+		value += pal16blueBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal16blue), pal16blue + pal16colors - 1);
 	}
 
-	for (uint8_t i = PAL16_YELLOW; i < PAL16_ORANGE; i++) {
-		uint8_t adj = 0;
-		if ((i == PAL16_YELLOW) && (pal16yellow % 16 != 0))
-			adj = 1;
-		int value = i - PAL16_YELLOW + pal16yellow + adj;
-		value = std::clamp(value, 0, 254);
-		customTrn[i] = static_cast<uint8_t>(value);
+	// Fill PAL16_YELLOW indices
+	for (int i = PAL16_YELLOW; i < PAL16_ORANGE; i++) {
+		int value = i - PAL16_YELLOW;
+		value += pal16yellow;
+		value += pal16yellowBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal16yellow), pal16yellow + pal16colors - 1);
 	}
 
-	for (uint8_t i = PAL16_ORANGE; i < PAL16_RED; i++) {
-		uint8_t adj = 0;
-		if ((i == PAL16_ORANGE) && (pal16orange % 16 != 0))
-			adj = 1;
-		int value = i - PAL16_ORANGE + pal16orange + adj;
-		value = std::clamp(value, 0, 254);
-		customTrn[i] = static_cast<uint8_t>(value);
+	// Fill PAL16_ORANGE indices
+	for (int i = PAL16_ORANGE; i < PAL16_RED; i++) {
+		int value = i - PAL16_ORANGE;
+		value += pal16orange;
+		value += pal16orangeBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal16orange), pal16orange + pal16colors - 1);
 	}
 
-	for (uint8_t i = PAL16_RED; i < PAL16_GRAY; i++) {
-		uint8_t adj = 0;
-		if ((i == PAL16_RED) && (pal16red % 16 != 0))
-			adj = 1;
-		int value = i - PAL16_RED + pal16red + adj;
-		value = std::clamp(value, 0, 254);
-		customTrn[i] = static_cast<uint8_t>(value);
+	// Fill PAL16_RED indices
+	for (int i = PAL16_RED; i < PAL16_GRAY; i++) {
+		int value = i - PAL16_RED;
+		value += pal16red;
+		value += pal16redBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal16red), pal16red + pal16colors - 1);
 	}
 
-	for (uint8_t i = PAL16_GRAY; i < PAL16_GRAY + 15; i++) {
-		uint8_t adj = 0;
-		if ((i == PAL16_GRAY) && (pal16gray % 16 != 0))
-			adj = 1;
-		int value = i - PAL16_GRAY + pal16gray + adj;
-		value = std::clamp(value, 0, 254);
-		customTrn[i] = static_cast<uint8_t>(value);
+	// Fill PAL16_GRAY indices
+	for (int i = PAL16_GRAY; i < PAL16_GRAY + pal16colors - 1; i++) {
+		int value = i - PAL16_GRAY;
+		value += pal16gray;
+		value += pal16grayBrightness;
+		customTrn[i] = clamp(value, static_cast<int>(pal16gray), pal16gray + pal16colors - 1);
+
 	}
 
-
-	customTrn[255] = 255;
+	for (int i = PAL8_BLUE; i < PAL16_GRAY + pal16colors; i++) {
+		if (customTrn[i] == 255) {
+			customTrn[i] = 0;
+		}
+	}
 
 	return customTrn.release();
 }

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -10,7 +10,7 @@
 
 namespace devilution {
 
-uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8red, int8_t pal8redBrightness, uint8_t pal8yellow, int8_t pal8yellowBrightness, uint8_t pal8orange, int8_t pal8orangeBrightness, uint8_t pal16beige, int8_t pal16beigeBrightness, uint8_t pal16blue, int8_t pal16blueBrightness, uint8_t pal16yellow, int8_t pal16yellowBrightness, uint8_t pal16orange, int8_t pal16orangeBrightness, uint8_t pal16red, int8_t pal16redBrightness, uint8_t pal16gray, int8_t pal16grayBrightness )
+uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueDimming, uint8_t pal8red, int8_t pal8redDimming, uint8_t pal8yellow, int8_t pal8yellowDimming, uint8_t pal8orange, int8_t pal8orangeDimming, uint8_t pal16beige, int8_t pal16beigeDimming, uint8_t pal16blue, int8_t pal16blueDimming, uint8_t pal16yellow, int8_t pal16yellowDimming, uint8_t pal16orange, int8_t pal16orangeDimming, uint8_t pal16red, int8_t pal16redDimming, uint8_t pal16gray, int8_t pal16grayDimming )
 {
 	std::unique_ptr<uint8_t[]> customTrn(new uint8_t[256]);
 	// Remaining colors on each line of colors after the first index
@@ -26,7 +26,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL8_BLUE; i < PAL8_RED; i++) {
 		int value = i - PAL8_BLUE;
 		value += pal8blue;
-		value += pal8blueBrightness;
+		value += pal8blueDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal8blue), pal8blue + pal8colors - 1);
 	}
 
@@ -34,7 +34,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL8_RED; i < PAL8_YELLOW; i++) {
 		int value = i - PAL8_RED;
 		value += pal8red;
-		value += pal8redBrightness;
+		value += pal8redDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal8red), pal8red + pal8colors - 1);
 	}
 
@@ -42,7 +42,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL8_YELLOW; i < PAL8_ORANGE; i++) {
 		int value = i - PAL8_YELLOW;
 		value += pal8yellow;
-		value += pal8yellowBrightness;
+		value += pal8yellowDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal8yellow), pal8yellow + pal8colors - 1);
 	}
 
@@ -50,7 +50,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL8_ORANGE; i < PAL16_BEIGE; i++) {
 		int value = i - PAL8_ORANGE;
 		value += pal8orange;
-		value += pal8orangeBrightness;
+		value += pal8orangeDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal8orange), pal8orange + pal8colors - 1);
 	}
 
@@ -58,7 +58,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL16_BEIGE; i < PAL16_BLUE; i++) {
 		int value = i - PAL16_BEIGE;
 		value += pal16beige;
-		value += pal16beigeBrightness;
+		value += pal16beigeDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal16beige), pal16beige + pal16colors - 1);
 	}
 
@@ -66,7 +66,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL16_BLUE; i < PAL16_YELLOW; i++) {
 		int value = i - PAL16_BLUE;
 		value += pal16blue;
-		value += pal16blueBrightness;
+		value += pal16blueDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal16blue), pal16blue + pal16colors - 1);
 	}
 
@@ -74,7 +74,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL16_YELLOW; i < PAL16_ORANGE; i++) {
 		int value = i - PAL16_YELLOW;
 		value += pal16yellow;
-		value += pal16yellowBrightness;
+		value += pal16yellowDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal16yellow), pal16yellow + pal16colors - 1);
 	}
 
@@ -82,7 +82,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL16_ORANGE; i < PAL16_RED; i++) {
 		int value = i - PAL16_ORANGE;
 		value += pal16orange;
-		value += pal16orangeBrightness;
+		value += pal16orangeDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal16orange), pal16orange + pal16colors - 1);
 	}
 
@@ -90,7 +90,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL16_RED; i < PAL16_GRAY; i++) {
 		int value = i - PAL16_RED;
 		value += pal16red;
-		value += pal16redBrightness;
+		value += pal16redDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal16red), pal16red + pal16colors - 1);
 	}
 
@@ -98,7 +98,7 @@ uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8r
 	for (int i = PAL16_GRAY; i < PAL16_GRAY + pal16colors - 1; i++) {
 		int value = i - PAL16_GRAY;
 		value += pal16gray;
-		value += pal16grayBrightness;
+		value += pal16grayDimming;
 		customTrn[i] = clamp(value, static_cast<int>(pal16gray), pal16gray + pal16colors - 1);
 
 	}

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -10,6 +10,91 @@
 
 namespace devilution {
 
+uint8_t *GetCustomTRN(uint8_t pal8blue, uint8_t pal8red, uint8_t pal8yellow, uint8_t pal8orange, uint8_t pal16beige, uint8_t pal16blue, uint8_t pal16yellow, uint8_t pal16orange, uint8_t pal16red, uint8_t pal16gray)
+{
+	std::unique_ptr<uint8_t[]> customTrn(new uint8_t[256]);
+
+	// Fill town/dungeon palette as default
+	for (uint8_t i = 0; i < 128; i++) {
+		customTrn[i] = i;
+	}
+
+	for (uint8_t i = PAL8_BLUE; i < PAL8_RED; i++) {
+		customTrn[i] = i - PAL8_BLUE + pal8blue;
+	}
+
+	for (uint8_t i = PAL8_RED; i < PAL8_YELLOW; i++) {
+		customTrn[i] = i - PAL8_RED + pal8red;
+	}
+
+	for (uint8_t i = PAL8_YELLOW; i < PAL8_ORANGE; i++) {
+		customTrn[i] = i - PAL8_YELLOW + pal8yellow;
+	}
+
+	for (uint8_t i = PAL8_ORANGE; i < PAL16_BEIGE; i++) {
+		customTrn[i] = i - PAL8_ORANGE + pal8orange;
+	}
+
+	for (uint8_t i = PAL16_BEIGE; i < PAL16_BLUE; i++) {
+		uint8_t adj = 0;
+		if ((i == PAL16_BEIGE) && (pal16beige % 16 != 0))
+			adj = 1;
+		int value = i - PAL16_BEIGE + pal16beige + adj;
+		value = std::clamp(value, 0, 254);
+		customTrn[i] = static_cast<uint8_t>(value);
+	}
+
+	for (uint8_t i = PAL16_BLUE; i < PAL16_YELLOW; i++) {
+		uint8_t adj = 0;
+		if ((i == PAL16_BLUE) && (pal16blue % 16 != 0))
+			adj = 1;
+		int value = i - PAL16_BLUE + pal16blue + adj;
+		value = std::clamp(value, 0, 254);
+		customTrn[i] = static_cast<uint8_t>(value);
+	}
+
+	for (uint8_t i = PAL16_YELLOW; i < PAL16_ORANGE; i++) {
+		uint8_t adj = 0;
+		if ((i == PAL16_YELLOW) && (pal16yellow % 16 != 0))
+			adj = 1;
+		int value = i - PAL16_YELLOW + pal16yellow + adj;
+		value = std::clamp(value, 0, 254);
+		customTrn[i] = static_cast<uint8_t>(value);
+	}
+
+	for (uint8_t i = PAL16_ORANGE; i < PAL16_RED; i++) {
+		uint8_t adj = 0;
+		if ((i == PAL16_ORANGE) && (pal16orange % 16 != 0))
+			adj = 1;
+		int value = i - PAL16_ORANGE + pal16orange + adj;
+		value = std::clamp(value, 0, 254);
+		customTrn[i] = static_cast<uint8_t>(value);
+	}
+
+	for (uint8_t i = PAL16_RED; i < PAL16_GRAY; i++) {
+		uint8_t adj = 0;
+		if ((i == PAL16_RED) && (pal16red % 16 != 0))
+			adj = 1;
+		int value = i - PAL16_RED + pal16red + adj;
+		value = std::clamp(value, 0, 254);
+		customTrn[i] = static_cast<uint8_t>(value);
+	}
+
+	for (uint8_t i = PAL16_GRAY; i < PAL16_GRAY + 15; i++) {
+		uint8_t adj = 0;
+		if ((i == PAL16_GRAY) && (pal16gray % 16 != 0))
+			adj = 1;
+		int value = i - PAL16_GRAY + pal16gray + adj;
+		value = std::clamp(value, 0, 254);
+		customTrn[i] = static_cast<uint8_t>(value);
+	}
+
+
+	customTrn[255] = 255;
+
+	return customTrn.release();
+}
+
 uint8_t *GetInfravisionTRN()
 {
 	return &LightTables[16 * 256];

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -11,7 +11,7 @@
 
 namespace devilution {
 
-uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8red, int8_t pal8redBrightness, uint8_t pal8yellow, int8_t pal8yellowBrightness, uint8_t pal8orange, int8_t pal8orangeBrightness, uint8_t pal16beige, int8_t pal16beigeBrightness, uint8_t pal16blue, int8_t pal16blueBrightness, uint8_t pal16yellow, int8_t pal16yellowBrightness, uint8_t pal16orange, int8_t pal16orangeBrightness, uint8_t pal16red, int8_t pal16redBrightness, uint8_t pal16gray, int8_t pal16grayBrightness);
+uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueDimming, uint8_t pal8red, int8_t pal8redDimming, uint8_t pal8yellow, int8_t pal8yellowDimming, uint8_t pal8orange, int8_t pal8orangeDimming, uint8_t pal16beige, int8_t pal16beigeDimming, uint8_t pal16blue, int8_t pal16blueDimming, uint8_t pal16yellow, int8_t pal16yellowDimming, uint8_t pal16orange, int8_t pal16orangeDimming, uint8_t pal16red, int8_t pal16redDimming, uint8_t pal16gray, int8_t pal16grayDimming);
 uint8_t *GetInfravisionTRN();
 uint8_t *GetStoneTRN();
 uint8_t *GetPauseTRN();

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -11,7 +11,7 @@
 
 namespace devilution {
 
-uint8_t *GetCustomTRN(uint8_t pal8blue = PAL8_BLUE, uint8_t pal8red = PAL8_RED, uint8_t pal8yellow = PAL8_YELLOW, uint8_t pal8orange = PAL8_ORANGE, uint8_t pal16beige = PAL16_BEIGE, uint8_t pal16blue = PAL16_BLUE, uint8_t pal16yellow = PAL16_YELLOW, uint8_t pal16orange = PAL16_ORANGE, uint8_t pal16red = PAL16_RED, uint8_t pal16gray = PAL16_GRAY);
+uint8_t *GetCustomTRN(uint8_t pal8blue, int8_t pal8blueBrightness, uint8_t pal8red, int8_t pal8redBrightness, uint8_t pal8yellow, int8_t pal8yellowBrightness, uint8_t pal8orange, int8_t pal8orangeBrightness, uint8_t pal16beige, int8_t pal16beigeBrightness, uint8_t pal16blue, int8_t pal16blueBrightness, uint8_t pal16yellow, int8_t pal16yellowBrightness, uint8_t pal16orange, int8_t pal16orangeBrightness, uint8_t pal16red, int8_t pal16redBrightness, uint8_t pal16gray, int8_t pal16grayBrightness);
 uint8_t *GetInfravisionTRN();
 uint8_t *GetStoneTRN();
 uint8_t *GetPauseTRN();

--- a/Source/engine/trn.hpp
+++ b/Source/engine/trn.hpp
@@ -5,11 +5,13 @@
  */
 #pragma once
 
+#include "engine/palette.h"
 #include "player.h"
 #include "utils/stdcompat/optional.hpp"
 
 namespace devilution {
 
+uint8_t *GetCustomTRN(uint8_t pal8blue = PAL8_BLUE, uint8_t pal8red = PAL8_RED, uint8_t pal8yellow = PAL8_YELLOW, uint8_t pal8orange = PAL8_ORANGE, uint8_t pal16beige = PAL16_BEIGE, uint8_t pal16blue = PAL16_BLUE, uint8_t pal16yellow = PAL16_YELLOW, uint8_t pal16orange = PAL16_ORANGE, uint8_t pal16red = PAL16_RED, uint8_t pal16gray = PAL16_GRAY);
 uint8_t *GetInfravisionTRN();
 uint8_t *GetStoneTRN();
 uint8_t *GetPauseTRN();


### PR DESCRIPTION
Adds a new function for swapping lines on the palette to make TRNs on the fly.

Every affix selects 1-3 different palette rows/subrows to swap, giving each affix a slightly different color variation. The goal is to add visual variation to items to make them more interesting (in the same way that monsters use TRNs to appear different).